### PR TITLE
fix(ci): upgrade GitHub Actions to resolve Node.js 20 deprecation

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           node-version: "22"
 
@@ -36,7 +36,7 @@ jobs:
           LANGCHAIN_TRACING_V2: "false"
 
       - name: Create OpenWiki update pull request
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           add-paths: |
             openwiki


### PR DESCRIPTION
## Problem
The OpenWiki Update workflow was failing with:
- `The process '/usr/bin/git' failed with exit code 1`
- Node.js 20 deprecation warning

All three GitHub Actions were targeting Node.js 20, which GitHub is force-running on Node.js 24, causing compatibility issues.

## Solution
Upgraded all actions to versions that natively support Node.js 24:
- `actions/checkout`: v4 → v7.0.0
- `actions/setup-node`: v4 → v7.0.1
- `peter-evans/create-pull-request`: v7.0.11 → v8.1.1

## Verification
The next scheduled workflow run (or manual trigger via `workflow_dispatch`) should succeed without the git error or Node.js deprecation warnings.