### PR TITLE
chore: enforce clang-format-18 via opt-in pre-commit hook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts must keep LF endings regardless of core.autocrlf — CRLF breaks
+# their shebang line (bash: $'\r': command not found) when executed via bash
+# (git-bash/MSYS on Windows, or any POSIX shell).
+.githooks/* text eol=lf
+scripts/*.sh text eol=lf

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Blocks commits that would fail CI's `format` job (see .github/workflows/build.yml).
+# Enable once per clone with:  git config core.hooksPath .githooks
+set -u
+
+# Directories/extensions must mirror the `format` job in .github/workflows/build.yml exactly.
+DIRS=(src app core common tests test_engine signal_generator amplifier spectrum_analyzer equalizer node_graph splitter mixer adc coax pfb_channelizer iq_plot icon_registry ideal_filter attenuator combiner touchstone logging)
+
+# Staged, non-deleted .cpp/.h files under the CI-checked directories. Check this FIRST so
+# commits that touch no C++ (docs, scripts, CI config, ...) never require clang-format at all.
+mapfile -t FILES < <(git diff --cached --name-only --diff-filter=ACMR -- "${DIRS[@]}" \
+  | grep -E '\.(cpp|h)$' || true)
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+# Resolve a clang-format binary pinned to major version 18 (CI uses clang-format-18).
+resolve_clang_format() {
+  for candidate in clang-format-18 clang-format; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      if "$candidate" --version 2>/dev/null | grep -q "version 18\."; then
+        echo "$candidate"
+        return 0
+      fi
+    fi
+  done
+  # Portable fallback: a pip-installed clang-format==18.1.8 wheel, if present.
+  local pip_bin="$HOME/.cache/clang-format-18/clang_format/data/bin/clang-format"
+  [ -f "${pip_bin}.exe" ] && pip_bin="${pip_bin}.exe"
+  if [ -x "$pip_bin" ] || [ -f "$pip_bin" ]; then
+    echo "$pip_bin"
+    return 0
+  fi
+  return 1
+}
+
+CF="$(resolve_clang_format)"
+if [ -z "$CF" ]; then
+  cat >&2 <<EOF
+pre-commit: clang-format 18 not found on PATH, but this commit touches C++ files:
+$(printf '  %s\n' "${FILES[@]}")
+
+Install it, then retry the commit:
+  Linux (apt):    sudo apt-get install -y clang-format-18
+  macOS (brew):   brew install llvm@18   # ensure its bin/ is on PATH
+  Any platform:   scripts/install-clang-format.sh  (pip install clang-format==18.1.8)
+
+To skip this check for one commit (NOT recommended, CI will still enforce it):
+  git commit --no-verify
+EOF
+  exit 1
+fi
+
+BAD=()
+for f in "${FILES[@]}"; do
+  [ -f "$f" ] || continue
+  if ! "$CF" --dry-run --Werror "$f" >/dev/null 2>&1; then
+    BAD+=("$f")
+  fi
+done
+
+if [ "${#BAD[@]}" -gt 0 ]; then
+  echo "pre-commit: clang-format violations in ${#BAD[@]} file(s) (would fail CI's format job):" >&2
+  printf '  %s\n' "${BAD[@]}" >&2
+  echo "Fix with: ${CF} -i ${BAD[*]}" >&2
+  exit 1
+fi
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,14 @@ cmake --build build
 
 The first build takes 60-90s while FetchContent clones dependencies. Subsequent builds are fast.
 
+**One-time setup — enable the format pre-commit hook** (blocks commits that would fail CI's `format` job):
+
+```bash
+git config core.hooksPath .githooks
+```
+
+If `clang-format-18` isn't available via your system package manager (e.g. Windows, older macOS), install a pinned copy: `scripts/install-clang-format.sh` (requires Python/pip; installs to `~/.cache/clang-format-18`, auto-detected by the hook and `scripts/format.sh`).
+
 > **See also:** [Build & Operations guide](openwiki/operations/build-runbook.md) for release builds, clean builds, CI/CD, and troubleshooting.
 
 ## Testing
@@ -72,7 +80,8 @@ Release tags (`v*`) trigger binary packaging and draft GitHub Releases with auto
 ## Code Style
 
 - **Format:** LLVM-based via [`.clang-format`](.clang-format) (4-space indent, 100 cols, `PointerAlignment: Right`).
-  Run `clang-format -i <file>` on every changed file before committing. CI will reject PRs with formatting violations.
+  Run `scripts/format.sh` to reformat changed files, or `scripts/format.sh --check` to dry-run (CI-equivalent). CI will reject PRs with formatting violations.
+  Enable `git config core.hooksPath .githooks` once per clone to catch this automatically on `git commit` — see Clone & Build above.
 - **DSP engine helpers** for ImGui inputs: `utils::inputDouble(label, ref, min, max)` and `utils::inputFrequency(label, freq_Hz, ...)`.
 - **Spectrum tone struct:** `{double freq_Hz, power_dBm, phase_deg}`.
 - **Test float comparisons** with `Catch::Approx` from `<catch2/catch_approx.hpp>`.

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Format (or check) C++ sources with the same clang-format-18 CI uses.
+#
+# Usage:
+#   scripts/format.sh              # reformat every changed file (working tree, vs. HEAD)
+#   scripts/format.sh --check      # dry-run + --Werror on every changed file (CI-equivalent)
+#   scripts/format.sh --all        # reformat the full CI-scanned file set, not just changed files
+#   scripts/format.sh file1 file2  # operate on explicit files
+#
+# If clang-format-18 isn't on PATH, run scripts/install-clang-format.sh first.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+DIRS=(src app core common tests test_engine signal_generator amplifier spectrum_analyzer equalizer node_graph splitter mixer adc coax pfb_channelizer iq_plot icon_registry ideal_filter attenuator combiner touchstone logging)
+
+resolve_clang_format() {
+  for candidate in clang-format-18 clang-format; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      if "$candidate" --version 2>/dev/null | grep -q "version 18\."; then
+        echo "$candidate"
+        return 0
+      fi
+    fi
+  done
+  local pip_bin="$HOME/.cache/clang-format-18/clang_format/data/bin/clang-format"
+  [ -f "${pip_bin}.exe" ] && pip_bin="${pip_bin}.exe"
+  if [ -x "$pip_bin" ] || [ -f "$pip_bin" ]; then
+    echo "$pip_bin"
+    return 0
+  fi
+  return 1
+}
+
+CF="$(resolve_clang_format)" || {
+  echo "format.sh: clang-format 18 not found. Run scripts/install-clang-format.sh first." >&2
+  exit 1
+}
+
+MODE="reformat"
+EXPLICIT_FILES=()
+for arg in "$@"; do
+  case "$arg" in
+    --check) MODE="check" ;;
+    --all) MODE="${MODE}-all" ;;
+    *) EXPLICIT_FILES+=("$arg") ;;
+  esac
+done
+
+if [ "${#EXPLICIT_FILES[@]}" -gt 0 ]; then
+  FILES=("${EXPLICIT_FILES[@]}")
+elif [[ "$MODE" == *-all ]]; then
+  mapfile -t FILES < <(find "${DIRS[@]}" -name '*.cpp' -o -name '*.h' 2>/dev/null)
+else
+  mapfile -t FILES < <(git diff --name-only --diff-filter=ACMR -- "${DIRS[@]}" \
+    | grep -E '\.(cpp|h)$' || true)
+fi
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo "format.sh: no matching files to process."
+  exit 0
+fi
+
+if [[ "$MODE" == check* ]]; then
+  BAD=()
+  for f in "${FILES[@]}"; do
+    [ -f "$f" ] || continue
+    "$CF" --dry-run --Werror "$f" >/dev/null 2>&1 || BAD+=("$f")
+  done
+  if [ "${#BAD[@]}" -gt 0 ]; then
+    echo "format.sh: ${#BAD[@]} file(s) need formatting:"
+    printf '  %s\n' "${BAD[@]}"
+    exit 1
+  fi
+  echo "format.sh: all ${#FILES[@]} file(s) clean."
+else
+  "$CF" -i "${FILES[@]}"
+  echo "format.sh: reformatted ${#FILES[@]} file(s)."
+fi

--- a/scripts/install-clang-format.sh
+++ b/scripts/install-clang-format.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Portable install of clang-format 18.1.8 for contributors/CI-parity checks when the
+# system package manager doesn't offer clang-format-18 (e.g. Windows, older macOS).
+# Installs via pip into a fixed cache dir so scripts/format.sh and .githooks/pre-commit
+# can find it without any extra configuration.
+set -euo pipefail
+
+DEST="$HOME/.cache/clang-format-18"
+
+PY=""
+for candidate in python3 python; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    PY="$candidate"
+    break
+  fi
+done
+if [ -z "$PY" ]; then
+  echo "install-clang-format: no python3/python found on PATH" >&2
+  exit 1
+fi
+
+"$PY" -m pip install --target "$DEST" clang-format==18.1.8
+
+BIN="$DEST/clang_format/data/bin/clang-format"
+[ -f "${BIN}.exe" ] && BIN="${BIN}.exe"
+if [ ! -x "$BIN" ] && [ ! -f "$BIN" ]; then
+  echo "install-clang-format: install succeeded but binary not found at $BIN" >&2
+  exit 1
+fi
+
+echo "clang-format 18 installed at: $BIN"
+"$BIN" --version


### PR DESCRIPTION
## Why

`feat/component-library-authoring-ui` (#26) hit the `format` CI check repeatedly because the 10 touched files were never run through `clang-format` before committing — the requirement exists only as a line in CONTRIBUTING.md ("run clang-format -i before committing"), nothing actually enforces it locally, so it's easy for it to slip (agent-driven or human).

## What

- **`.githooks/pre-commit`** (tracked, opt-in via `git config core.hooksPath .githooks`): checks only staged `.cpp`/`.h` files under the same directories CI's `format` job scans; blocks the commit with the exact violating files + a one-line fix command if any fail `clang-format-18 --dry-run --Werror`. No-ops instantly (no clang-format dependency at all) for commits that don't touch C++.
- **`scripts/format.sh`**: `scripts/format.sh` reformats changed files, `--check` dry-runs (CI-equivalent), `--all` covers the full CI-scanned file set.
- **`scripts/install-clang-format.sh`**: portable fallback (`pip install clang-format==18.1.8`) for platforms without a `clang-format-18` system package (Windows, older macOS) — this is exactly what unblocked PR #26's format failure. Installs to `~/.cache/clang-format-18`, auto-detected by both the hook and `format.sh`.
- **`.gitattributes`**: forces LF on `.githooks/*` and `scripts/*.sh` regardless of `core.autocrlf`, so the shebang lines don't get CRLF-mangled and break execution via bash on Windows clones.
- **CONTRIBUTING.md**: documents the one-time `git config core.hooksPath .githooks` setup step and points to the new scripts.

## Non-goals

- Not made mandatory/auto-enabled (git doesn't support repo-committed hooks that self-activate) — it's a one-line opt-in documented in CONTRIBUTING.md's Clone & Build section. CI's `format` job remains the actual enforcement backstop regardless.
- Doesn't touch `.clang-format` itself or any source files.

## Testing

- `bash -n` syntax-checked all three shell scripts.
- Verified end-to-end against a real `clang-format==18.1.8` install (matching CI's `clang-format-18` exactly): hook correctly blocks a staged file with real violations, correctly passes commits touching no C++ files without requiring clang-format at all, and the underlying `--dry-run --Werror` detection matches what fixed PR #26's format failure.
