### PR TITLE
feat: add plugin extension system for external tools and data packs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,7 @@ jobs:
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-ninja
             mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-python
 
       - name: ccache
         if: runner.os == 'Linux'

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -2,19 +2,23 @@
 
 ## What I implemented
 - Added `ExtensionManager` in `app/include/extension_manager.h` and `app/src/extension_manager.cpp`.
-- Discovery now scans the three planned roots:
+- Discovery scans the three planned roots:
   - built-in: `PROJECT_SOURCE_DIR/extensions`
   - global: `~/.rf-sim/extensions` via `USERPROFILE` on Windows or `HOME` elsewhere
   - project-local: `<project_root>/rf-sim-extensions`
 - Each extension folder is discovered via its `plugin.json` manifest.
 - Invalid manifests are preserved as visible `ExtensionRecord` entries with `status == ExtensionStatusKind::Invalid`, their `issues`, and a manifest path.
 - Valid manifests are classified into `dataPacks()` and `externalTools()` based on manifest kind.
-- Added compatibility-aware status tracking: manifests with `compat.min_app_version` above the current app version are marked `ExtensionStatusKind::Incompatible`.
+- Compatibility-aware status tracking marks manifests with `compat.min_app_version` above the current app version as `ExtensionStatusKind::Incompatible`.
+- Added precedence shadowing by extension id so higher-precedence roots win and lower-precedence copies do not appear in `all()`.
+- Updated active query helpers so incompatible manifests stay visible in discovery/status but are excluded from `dataPacks()` and `externalTools()`.
 - Updated `app/CMakeLists.txt` so the new manager source is compiled into `simulator::app`.
 - Updated `app/AGENTS.md` with the ExtensionManager ownership/status note.
 - Added focused discovery tests in `tests/test_extensions.cpp` for:
   - a valid project-local data pack
   - a malformed manifest that remains visible as an invalid record
+  - project-local precedence over built-in copies
+  - incompatible manifests remaining visible but excluded from active queries
 
 ## What I tested and results
 - `cmake --build build --target test_extensions`
@@ -32,9 +36,16 @@
 
 ## Self-review findings
 - Discovery is deterministic within each root by sorting manifest paths before loading.
+- Higher-precedence roots overwrite lower-precedence records that share the same extension id.
 - Invalid manifests stay visible in `all()` instead of being dropped.
-- Classification helpers return parsed manifests only; invalid entries are excluded because they have no manifest object.
+- `dataPacks()` and `externalTools()` now return only active, compatible manifests.
 - Compatibility status is derived from `compat.min_app_version` against `APP_VERSION`.
 
 ## Issues or concerns
 - No blocking issues remaining.
+
+## Reviewer-fix update
+- Re-ran the focused extension build and test command after adding precedence shadowing and active-query filtering.
+- Both commands still passed:
+  - `cmake --build build --target test_extensions`
+  - `ctest --test-dir build -R test_extensions --output-on-failure`

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -58,3 +58,10 @@
 - Both commands still passed:
   - `cmake --build build --target test_extensions`
   - `ctest --test-dir build -R test_extensions --output-on-failure`
+
+## Reviewer-fix update 3
+- Restructured directory iteration so each entry is processed before advancing, avoiding loss of the current manifest if an entry becomes unreadable mid-scan.
+- Re-ran the focused extension build and test command again after that fix.
+- Both commands still passed:
+  - `cmake --build build --target test_extensions`
+  - `ctest --test-dir build -R test_extensions --output-on-failure`

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,0 +1,40 @@
+# Task 2 Report: Discovery and extension status tracking
+
+## What I implemented
+- Added `ExtensionManager` in `app/include/extension_manager.h` and `app/src/extension_manager.cpp`.
+- Discovery now scans the three planned roots:
+  - built-in: `PROJECT_SOURCE_DIR/extensions`
+  - global: `~/.rf-sim/extensions` via `USERPROFILE` on Windows or `HOME` elsewhere
+  - project-local: `<project_root>/rf-sim-extensions`
+- Each extension folder is discovered via its `plugin.json` manifest.
+- Invalid manifests are preserved as visible `ExtensionRecord` entries with `status == ExtensionStatusKind::Invalid`, their `issues`, and a manifest path.
+- Valid manifests are classified into `dataPacks()` and `externalTools()` based on manifest kind.
+- Added compatibility-aware status tracking: manifests with `compat.min_app_version` above the current app version are marked `ExtensionStatusKind::Incompatible`.
+- Updated `app/CMakeLists.txt` so the new manager source is compiled into `simulator::app`.
+- Updated `app/AGENTS.md` with the ExtensionManager ownership/status note.
+- Added focused discovery tests in `tests/test_extensions.cpp` for:
+  - a valid project-local data pack
+  - a malformed manifest that remains visible as an invalid record
+
+## What I tested and results
+- `cmake --build build --target test_extensions`
+  - Passed.
+- `ctest --test-dir build -R test_extensions --output-on-failure`
+  - Passed: 1/1 test executable succeeded.
+
+## Files changed
+- `app/include/extension_manager.h`
+- `app/src/extension_manager.cpp`
+- `app/CMakeLists.txt`
+- `app/AGENTS.md`
+- `tests/test_extensions.cpp`
+- `.superpowers/sdd/task-2-report.md`
+
+## Self-review findings
+- Discovery is deterministic within each root by sorting manifest paths before loading.
+- Invalid manifests stay visible in `all()` instead of being dropped.
+- Classification helpers return parsed manifests only; invalid entries are excluded because they have no manifest object.
+- Compatibility status is derived from `compat.min_app_version` against `APP_VERSION`.
+
+## Issues or concerns
+- No blocking issues remaining.

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -11,14 +11,16 @@
 - Valid manifests are classified into `dataPacks()` and `externalTools()` based on manifest kind.
 - Compatibility-aware status tracking marks manifests with `compat.min_app_version` above the current app version as `ExtensionStatusKind::Incompatible`.
 - Added precedence shadowing by extension id so higher-precedence roots win and lower-precedence copies do not appear in `all()`.
-- Updated active query helpers so incompatible manifests stay visible in discovery/status but are excluded from `dataPacks()` and `externalTools()`.
+- Active query helpers return only compatible manifests; incompatible manifests stay visible in discovery/status but are excluded from `dataPacks()` and `externalTools()`.
+- Discovery is resilient to filesystem failures in a root; failed roots are skipped rather than aborting the whole scan.
+- Malformed `compat.min_app_version` strings are treated as incompatible so they do not leak into active query APIs.
 - Updated `app/CMakeLists.txt` so the new manager source is compiled into `simulator::app`.
 - Updated `app/AGENTS.md` with the ExtensionManager ownership/status note.
 - Added focused discovery tests in `tests/test_extensions.cpp` for:
   - a valid project-local data pack
   - a malformed manifest that remains visible as an invalid record
   - project-local precedence over built-in copies
-  - incompatible manifests remaining visible but excluded from active queries
+  - malformed compatibility strings remaining visible but excluded from active queries
 
 ## What I tested and results
 - `cmake --build build --target test_extensions`
@@ -46,6 +48,13 @@
 
 ## Reviewer-fix update
 - Re-ran the focused extension build and test command after adding precedence shadowing and active-query filtering.
+- Both commands still passed:
+  - `cmake --build build --target test_extensions`
+  - `ctest --test-dir build -R test_extensions --output-on-failure`
+
+## Reviewer-fix update 2
+- Reworked root scanning to avoid aborting on filesystem errors and updated compatibility parsing so malformed version strings are treated as incompatible.
+- Re-ran the focused extension build and test command again after that fix.
 - Both commands still passed:
   - `cmake --build build --target test_extensions`
   - `ctest --test-dir build -R test_extensions --output-on-failure`

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -10,7 +10,6 @@ Application orchestrator layer containing `RfSimulatorApp`, `ComponentRegistry`,
 - `ComponentTypeRegistry` — data-driven type schema table (field lists + factories) used by `ComponentLibrary::instantiate()`/`validate()` and the component authoring form
 - `ComponentFormModel` / `ComponentFormWidget` — pure-logic + ImGui rendering pair for the New/Edit Component form
 - `ExtensionManager` — extension manifest discovery and status tracking across built-in/global/project-local roots
-
 ## Local Contracts
 - `saveProject()` / `loadProject()` / `newProject()` handle full project serialization to `.rfsim` JSON format
 - Dirty tracking propagated via `markDirty()` / `onParamChange` / `onLinkChanged` callbacks

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -9,6 +9,7 @@ Application orchestrator layer containing `RfSimulatorApp`, `ComponentRegistry`,
 - `InspectorPanel` — property editing panel with dirty tracking
 - `ComponentTypeRegistry` — data-driven type schema table (field lists + factories) used by `ComponentLibrary::instantiate()`/`validate()` and the component authoring form
 - `ComponentFormModel` / `ComponentFormWidget` — pure-logic + ImGui rendering pair for the New/Edit Component form
+- `ExtensionManager` — extension manifest discovery and status tracking across built-in/global/project-local roots
 
 ## Local Contracts
 - `saveProject()` / `loadProject()` / `newProject()` handle full project serialization to `.rfsim` JSON format
@@ -16,6 +17,7 @@ Application orchestrator layer containing `RfSimulatorApp`, `ComponentRegistry`,
 - File menu bar in `draw_ui()` handles keyboard shortcuts (`Ctrl+N`, `Ctrl+O`, `Ctrl+S`, `Ctrl+Shift+S`) and unsaved-changes modal; Help menu provides F1-toggled help window
 - View menu's `Layouts` submenu (Save As.../Load/Manage...) drives `LayoutManager` (see `layout/AGENTS.md`) for named window-layout presets; the exe-relative default layout is auto-managed by ImGui itself via `IniFilename`, set in `core/src/core.cpp`
 - Library browser's "New Component..."/"Edit" flow writes schema-v2 JSON via `ComponentFormModel::buildDefinition()`; new entries save to a user-chosen root (`rf-sim-libraries/` project-local or `~/.rf-sim/libraries/` global); built-in `component_data/library/` entries are read-only (no Edit button) and never a save target; edits always overwrite the original `source_path` (no rename-on-identity-change)
+- Extension discovery stays inside `app/` and scans built-in, global, and project-local roots; invalid manifests remain visible via `ExtensionManager::all()`
 - `load_window_states()` runs on construction to restore persisted window visibility toggles
 - Destructor saves window state via `SessionState`
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -18,6 +18,10 @@ Application orchestrator layer containing `RfSimulatorApp`, `ComponentRegistry`,
 - View menu's `Layouts` submenu (Save As.../Load/Manage...) drives `LayoutManager` (see `layout/AGENTS.md`) for named window-layout presets; the exe-relative default layout is auto-managed by ImGui itself via `IniFilename`, set in `core/src/core.cpp`
 - Library browser's "New Component..."/"Edit" flow writes schema-v2 JSON via `ComponentFormModel::buildDefinition()`; new entries save to a user-chosen root (`rf-sim-libraries/` project-local or `~/.rf-sim/libraries/` global); built-in `component_data/library/` entries are read-only (no Edit button) and never a save target; edits always overwrite the original `source_path` (no rename-on-identity-change)
 - Extension discovery stays inside `app/` and scans built-in, global, and project-local roots; invalid manifests remain visible via `ExtensionManager::all()`
+- External tools run only through `ExternalToolRunner` on explicit user action; the runner writes a JSON request file, waits for the tool to finish, and treats a missing/invalid result file as failure
+- `refreshExtensions()` rescans built-in, global, and project-local roots for the current project path and rebuilds the component library before the browser/UI reads from it
+- `draw_ui()` exposes the Tools menu, `drawExtensionsPanel()` shows discovery status plus manual refresh, and `runExternalTool()` refreshes discovery after a successful run while updating `m_extension_result_message`
+- App-level integration tests may use `testExtensionManager()` and `testExtensionResultMessage()` with an ImGui/ImPlot/ImNodes fixture
 - `load_window_states()` runs on construction to restore persisted window visibility toggles
 - Destructor saves window state via `SessionState`
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -10,6 +10,7 @@ Application orchestrator layer containing `RfSimulatorApp`, `ComponentRegistry`,
 - `ComponentTypeRegistry` — data-driven type schema table (field lists + factories) used by `ComponentLibrary::instantiate()`/`validate()` and the component authoring form
 - `ComponentFormModel` / `ComponentFormWidget` — pure-logic + ImGui rendering pair for the New/Edit Component form
 - `ExtensionManager` — extension manifest discovery and status tracking across built-in/global/project-local roots
+- `ExternalToolRunner` — structured request/result execution for approved external tools
 ## Local Contracts
 - `saveProject()` / `loadProject()` / `newProject()` handle full project serialization to `.rfsim` JSON format
 - Dirty tracking propagated via `markDirty()` / `onParamChange` / `onLinkChanged` callbacks

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -19,8 +19,10 @@ Application orchestrator layer containing `RfSimulatorApp`, `ComponentRegistry`,
 - Library browser's "New Component..."/"Edit" flow writes schema-v2 JSON via `ComponentFormModel::buildDefinition()`; new entries save to a user-chosen root (`rf-sim-libraries/` project-local or `~/.rf-sim/libraries/` global); built-in `component_data/library/` entries are read-only (no Edit button) and never a save target; edits always overwrite the original `source_path` (no rename-on-identity-change)
 - Extension discovery stays inside `app/` and scans built-in, global, and project-local roots; invalid manifests remain visible via `ExtensionManager::all()`
 - External tools run only through `ExternalToolRunner` on explicit user action; the runner writes a JSON request file, waits for the tool to finish, and treats a missing/invalid result file as failure
+- `runExternalTool()` serializes the clicked action label as `action_label`, clears any stale prior `result.json` before launch, refreshes discovery after a successful run, and updates `m_extension_result_message`
+- `externalToolActions()` is the single policy for launchable tool actions: declared `menus[]` entries pass through unchanged; tools with no menus get one synthetic `"tools"` action using `manifest.name`
 - `refreshExtensions()` rescans built-in, global, and project-local roots for the current project path and rebuilds the component library before the browser/UI reads from it
-- `draw_ui()` exposes the Tools menu, `drawExtensionsPanel()` shows discovery status plus manual refresh, and `runExternalTool()` refreshes discovery after a successful run while updating `m_extension_result_message`
+- `draw_ui()` and `drawExtensionsPanel()` both dispatch through `externalToolActions()`; the Tools menu renders only actions whose `location == "tools"`, while the Extensions panel shows every declared action (or a single fallback Run button)
 - App-level integration tests may use `testExtensionManager()` and `testExtensionResultMessage()` with an ImGui/ImPlot/ImNodes fixture
 - `load_window_states()` runs on construction to restore persisted window visibility toggles
 - Destructor saves window state via `SessionState`

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(app STATIC
     src/component_form_widget.cpp
     src/extension_manifest.cpp
     src/extension_manager.cpp
+    src/external_tool_runner.cpp
 )
 add_library(simulator::app ALIAS app)
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -5,7 +5,7 @@ project(app LANGUAGES CXX)
 # --------------------------------------------------
 # App library
 # --------------------------------------------------
-add_library(app STATIC src/app.cpp src/inspector_panel.cpp src/component_registry.cpp src/component_library.cpp src/library_browser_widget.cpp src/component_type_registry.cpp src/component_form_model.cpp src/component_form_widget.cpp)
+add_library(app STATIC src/app.cpp src/inspector_panel.cpp src/component_registry.cpp src/component_library.cpp src/library_browser_widget.cpp src/component_type_registry.cpp src/component_form_model.cpp src/component_form_widget.cpp src/extension_manifest.cpp)
 add_library(simulator::app ALIAS app)
 
 # --------------------------------------------------

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -5,7 +5,18 @@ project(app LANGUAGES CXX)
 # --------------------------------------------------
 # App library
 # --------------------------------------------------
-add_library(app STATIC src/app.cpp src/inspector_panel.cpp src/component_registry.cpp src/component_library.cpp src/library_browser_widget.cpp src/component_type_registry.cpp src/component_form_model.cpp src/component_form_widget.cpp src/extension_manifest.cpp)
+add_library(app STATIC
+    src/app.cpp
+    src/inspector_panel.cpp
+    src/component_registry.cpp
+    src/component_library.cpp
+    src/library_browser_widget.cpp
+    src/component_type_registry.cpp
+    src/component_form_model.cpp
+    src/component_form_widget.cpp
+    src/extension_manifest.cpp
+    src/extension_manager.cpp
+)
 add_library(simulator::app ALIAS app)
 
 # --------------------------------------------------

--- a/app/include/app.h
+++ b/app/include/app.h
@@ -10,6 +10,8 @@
 #include "component_registry.h"
 #include "component_type_registry.h"
 #include "equalizer_engine.h"
+#include "extension_manager.h"
+#include "external_tool_runner.h"
 
 #include "help_widget.h"
 #include "ideal_filter_engine.h"
@@ -40,6 +42,9 @@ class RfSimulatorApp {
     RfSimulatorApp();
     void draw_ui();
     void update_dsp();
+    void refreshExtensions();
+    void drawExtensionsPanel();
+    void runExternalTool(const ExtensionManifest &manifest);
 
     LoggingWidget m_log_widget;
     bool m_show_log = true;
@@ -54,6 +59,11 @@ class RfSimulatorApp {
     char m_layout_name_buf[128] = {};
     std::string m_rename_target;
     char m_rename_buf[128] = {};
+    ExtensionManager m_extension_manager;
+    ExternalToolRunner m_external_tool_runner;
+    bool m_show_extensions = false;
+    std::string m_extension_result_message;
+
     SessionState m_state;
     ~RfSimulatorApp();
 
@@ -72,6 +82,8 @@ class RfSimulatorApp {
     ComponentRegistry &testComponents() { return m_components; }
     NodeGraphWidget &testGraphWidget() { return *m_graph_widget; }
     LayoutManager &testLayoutManager() { return m_layout_manager; }
+    ExtensionManager &testExtensionManager() { return m_extension_manager; }
+    const std::string &testExtensionResultMessage() const { return m_extension_result_message; }
 
     void openFileDialog();
     void saveFileDialog();

--- a/app/include/app.h
+++ b/app/include/app.h
@@ -34,6 +34,7 @@
 #include "view_manager.h"
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <vector>
 enum class PendingAction { None, New, Open, Exit };
 
@@ -44,8 +45,8 @@ class RfSimulatorApp {
     void update_dsp();
     void refreshExtensions();
     void drawExtensionsPanel();
-    void runExternalTool(const ExtensionManifest &manifest);
-
+    std::vector<ExtensionMenuEntry> externalToolActions(const ExtensionManifest &manifest) const;
+    void runExternalTool(const ExtensionManifest &manifest, std::string_view action_label = {});
     LoggingWidget m_log_widget;
     bool m_show_log = true;
     bool m_show_spectrum = true;

--- a/app/include/extension_manager.h
+++ b/app/include/extension_manager.h
@@ -4,6 +4,7 @@
 
 #include <filesystem>
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 struct ExtensionRecord {
@@ -24,6 +25,7 @@ class ExtensionManager {
   private:
     std::vector<std::filesystem::path> scanRoots(const std::filesystem::path &project_root) const;
     void loadRoot(const std::filesystem::path &root);
+    std::unordered_map<std::string, std::size_t> m_records_by_id;
 
     std::vector<ExtensionRecord> m_records;
 };

--- a/app/include/extension_manager.h
+++ b/app/include/extension_manager.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "extension_manifest.h"
+
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+struct ExtensionRecord {
+    ExtensionStatusKind status = ExtensionStatusKind::Invalid;
+    std::filesystem::path manifest_path;
+    std::vector<ExtensionValidationIssue> issues;
+    std::optional<ExtensionManifest> manifest;
+};
+
+class ExtensionManager {
+  public:
+    void rescan(const std::filesystem::path &project_root);
+
+    const std::vector<ExtensionRecord> &all() const { return m_records; }
+    std::vector<const ExtensionManifest *> dataPacks() const;
+    std::vector<const ExtensionManifest *> externalTools() const;
+
+  private:
+    std::vector<std::filesystem::path> scanRoots(const std::filesystem::path &project_root) const;
+    void loadRoot(const std::filesystem::path &root);
+
+    std::vector<ExtensionRecord> m_records;
+};

--- a/app/include/extension_manifest.h
+++ b/app/include/extension_manifest.h
@@ -49,6 +49,6 @@ struct ExtensionManifest {
     std::vector<std::filesystem::path> data_roots;
 };
 
-std::optional<ExtensionManifest> parseExtensionManifest(
-    const std::filesystem::path &manifest_path,
-    std::vector<ExtensionValidationIssue> &issues);
+std::optional<ExtensionManifest>
+parseExtensionManifest(const std::filesystem::path &manifest_path,
+                       std::vector<ExtensionValidationIssue> &issues);

--- a/app/include/extension_manifest.h
+++ b/app/include/extension_manifest.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+enum class ExtensionKind {
+    DataPack,
+    ExternalTool,
+};
+
+enum class ExtensionCapability {
+    Generator,
+    Importer,
+};
+
+enum class ExtensionStatusKind {
+    Ok,
+    Invalid,
+    Incompatible,
+};
+
+struct ExtensionMenuEntry {
+    std::string location;
+    std::string label;
+};
+
+struct ExtensionValidationIssue {
+    std::string field;
+    std::string message;
+};
+
+struct ExtensionManifest {
+    int schema_version = 0;
+    std::string id;
+    std::string name;
+    std::string version;
+    std::string description;
+    std::string author;
+    std::string min_app_version;
+    ExtensionKind kind = ExtensionKind::DataPack;
+    std::vector<ExtensionCapability> capabilities;
+    std::filesystem::path manifest_path;
+    std::filesystem::path root_dir;
+    std::filesystem::path entry_path;
+    std::vector<ExtensionMenuEntry> menus;
+    std::vector<std::filesystem::path> library_roots;
+    std::vector<std::filesystem::path> data_roots;
+};
+
+std::optional<ExtensionManifest> parseExtensionManifest(
+    const std::filesystem::path &manifest_path,
+    std::vector<ExtensionValidationIssue> &issues);

--- a/app/include/external_tool_runner.h
+++ b/app/include/external_tool_runner.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "extension_manifest.h"
+
+#include <filesystem>
+#include <string>
+
+struct ExternalToolRequest {
+    std::string contract_version;
+    std::string action_label;
+    std::filesystem::path project_root;
+    std::filesystem::path selected_path;
+    std::filesystem::path work_dir;
+    std::filesystem::path result_path;
+};
+
+struct ExternalToolRunResult {
+    bool ok = false;
+    int exit_code = -1;
+    std::string message;
+    std::filesystem::path result_path;
+    std::filesystem::path work_dir;
+};
+
+class ExternalToolRunner {
+  public:
+    ExternalToolRunResult run(const ExtensionManifest &manifest,
+                              const ExternalToolRequest &request) const;
+};

--- a/app/src/app.cpp
+++ b/app/src/app.cpp
@@ -145,21 +145,7 @@ RfSimulatorApp::RfSimulatorApp() : m_components(m_graph_engine, m_view_manager) 
                                        &m_show_node_editor});
     m_inspector_panel->onParamChange = [this]() { markDirty(); };
 
-    // Initialize component library
-#ifdef _WIN32
-    const char *home = std::getenv("USERPROFILE");
-#else
-    const char *home = std::getenv("HOME");
-#endif
-    if (home) {
-        m_library.scan((std::filesystem::path(home) / ".rf-sim" / "libraries").string());
-    }
-    if (std::filesystem::exists("rf-sim-libraries")) {
-        m_library.scan("rf-sim-libraries");
-    }
-    if (std::filesystem::exists("component_data/library")) {
-        m_library.scan("component_data/library");
-    }
+    refreshExtensions();
 
     m_library_browser = std::make_unique<LibraryBrowserWidget>(m_library);
     m_library_browser->onInsert = [this](const ComponentDefinition &def) {
@@ -290,12 +276,108 @@ void RfSimulatorApp::newProject() {
     m_next_component_id = 100;
     m_current_project_path.clear();
     m_graph_widget->clearPositionCache();
+    refreshExtensions();
+
     m_dirty = false;
 }
 
 void RfSimulatorApp::testMakeDirty() { markDirty(); }
 
 void RfSimulatorApp::markDirty() { m_dirty = true; }
+void RfSimulatorApp::refreshExtensions() {
+    namespace fs = std::filesystem;
+
+    fs::path project_root = m_current_project_path.empty()
+                                ? fs::current_path()
+                                : fs::path(m_current_project_path).parent_path();
+    if (project_root.empty())
+        project_root = fs::current_path();
+
+    m_extension_manager.rescan(project_root);
+    m_library = ComponentLibrary{};
+
+#ifdef _WIN32
+    const char *home = std::getenv("USERPROFILE");
+#else
+    const char *home = std::getenv("HOME");
+#endif
+    if (home) {
+        m_library.scan((fs::path(home) / ".rf-sim" / "libraries").string());
+    }
+    if (fs::exists("rf-sim-libraries")) {
+        m_library.scan("rf-sim-libraries");
+    }
+    if (fs::exists("component_data/library")) {
+        m_library.scan("component_data/library");
+    }
+
+    for (const auto *pack : m_extension_manager.dataPacks()) {
+        for (const auto &root : pack->library_roots)
+            m_library.scan(root.string());
+    }
+}
+
+void RfSimulatorApp::runExternalTool(const ExtensionManifest &manifest) {
+    namespace fs = std::filesystem;
+
+    const fs::path project_root = m_current_project_path.empty()
+                                      ? fs::current_path()
+                                      : fs::path(m_current_project_path).parent_path();
+    const fs::path selected_path =
+        m_current_project_path.empty() ? fs::path{} : fs::path(m_current_project_path);
+    const fs::path work_dir = fs::temp_directory_path() / "rf-sim-extension-run" / manifest.id;
+    const ExternalToolRequest request{"1",           manifest.name, project_root,
+                                      selected_path, work_dir,      work_dir / "result.json"};
+
+    const auto result = m_external_tool_runner.run(manifest, request);
+    m_extension_result_message = result.ok ? "Extension run succeeded: " + manifest.name
+                                           : "Extension run failed: " + result.message;
+    if (result.ok)
+        refreshExtensions();
+}
+
+void RfSimulatorApp::drawExtensionsPanel() {
+    if (!m_show_extensions)
+        return;
+
+    if (ImGui::Begin("Extensions", &m_show_extensions)) {
+        if (ImGui::Button("Refresh"))
+            refreshExtensions();
+        if (!m_extension_result_message.empty())
+            ImGui::TextWrapped("%s", m_extension_result_message.c_str());
+        else
+            ImGui::TextDisabled("No extension actions run yet.");
+
+        ImGui::Separator();
+
+        for (const auto &record : m_extension_manager.all()) {
+            const bool has_manifest = record.manifest.has_value();
+            const std::string label =
+                has_manifest ? record.manifest->name : record.manifest_path.filename().string();
+            const char *status = record.status == ExtensionStatusKind::Ok ? "Ok"
+                                 : record.status == ExtensionStatusKind::Incompatible
+                                     ? "Incompatible"
+                                     : "Invalid";
+
+            ImGui::Text("%s [%s]", label.c_str(), status);
+            if (has_manifest && record.status == ExtensionStatusKind::Ok &&
+                record.manifest->kind == ExtensionKind::ExternalTool) {
+                ImGui::SameLine();
+                const std::string run_label = "Run##" + record.manifest->id;
+                if (ImGui::Button(run_label.c_str()))
+                    runExternalTool(*record.manifest);
+            }
+
+            if (!record.issues.empty()) {
+                ImGui::Indent();
+                for (const auto &issue : record.issues)
+                    ImGui::TextWrapped("%s: %s", issue.field.c_str(), issue.message.c_str());
+                ImGui::Unindent();
+            }
+        }
+    }
+    ImGui::End();
+}
 
 void RfSimulatorApp::saveProject(const std::string &path) {
     nlohmann::json root;
@@ -628,6 +710,8 @@ void RfSimulatorApp::loadProject(const std::string &path) {
     }
 
     m_current_project_path = path;
+    refreshExtensions();
+
     m_dirty = false;
     LOG_INFO("Loaded project from %s", path.c_str());
 }
@@ -924,6 +1008,24 @@ void RfSimulatorApp::draw_ui() {
             }
             ImGui::EndMenu();
         }
+        if (ImGui::BeginMenu("Tools")) {
+            ImGui::MenuItem("Extensions", nullptr, &m_show_extensions);
+            ImGui::Separator();
+            for (const auto *tool : m_extension_manager.externalTools()) {
+                if (!tool)
+                    continue;
+                if (tool->menus.empty()) {
+                    if (ImGui::MenuItem(tool->name.c_str()))
+                        runExternalTool(*tool);
+                }
+                for (const auto &menu : tool->menus) {
+                    if (menu.location == "tools" && ImGui::MenuItem(menu.label.c_str()))
+                        runExternalTool(*tool);
+                }
+            }
+            ImGui::EndMenu();
+        }
+
         if (ImGui::BeginMenu("Help")) {
             if (ImGui::MenuItem("How to Use", "F1"))
                 m_show_help = !m_show_help;
@@ -1156,6 +1258,7 @@ void RfSimulatorApp::draw_ui() {
     if (m_show_library && m_library_browser) {
         m_library_browser->draw("Component Library", &m_show_library);
     }
+    drawExtensionsPanel();
 
     if (m_show_log)
         m_log_widget.draw("Log", &m_show_log);

--- a/app/src/app.cpp
+++ b/app/src/app.cpp
@@ -317,17 +317,31 @@ void RfSimulatorApp::refreshExtensions() {
     }
 }
 
-void RfSimulatorApp::runExternalTool(const ExtensionManifest &manifest) {
+std::vector<ExtensionMenuEntry>
+RfSimulatorApp::externalToolActions(const ExtensionManifest &manifest) const {
+    if (!manifest.menus.empty())
+        return manifest.menus;
+    return {ExtensionMenuEntry{"tools", manifest.name}};
+}
+
+void RfSimulatorApp::runExternalTool(const ExtensionManifest &manifest,
+                                     std::string_view action_label) {
     namespace fs = std::filesystem;
 
+    const std::string effective_action_label =
+        action_label.empty() ? manifest.name : std::string(action_label);
     const fs::path project_root = m_current_project_path.empty()
                                       ? fs::current_path()
                                       : fs::path(m_current_project_path).parent_path();
     const fs::path selected_path =
         m_current_project_path.empty() ? fs::path{} : fs::path(m_current_project_path);
     const fs::path work_dir = fs::temp_directory_path() / "rf-sim-extension-run" / manifest.id;
-    const ExternalToolRequest request{"1",           manifest.name, project_root,
-                                      selected_path, work_dir,      work_dir / "result.json"};
+    const fs::path result_path = work_dir / "result.json";
+    std::error_code ec;
+    fs::remove(result_path, ec);
+
+    const ExternalToolRequest request{
+        "1", effective_action_label, project_root, selected_path, work_dir, result_path};
 
     const auto result = m_external_tool_runner.run(manifest, request);
     m_extension_result_message = result.ok ? "Extension run succeeded: " + manifest.name
@@ -362,10 +376,17 @@ void RfSimulatorApp::drawExtensionsPanel() {
             ImGui::Text("%s [%s]", label.c_str(), status);
             if (has_manifest && record.status == ExtensionStatusKind::Ok &&
                 record.manifest->kind == ExtensionKind::ExternalTool) {
-                ImGui::SameLine();
-                const std::string run_label = "Run##" + record.manifest->id;
-                if (ImGui::Button(run_label.c_str()))
-                    runExternalTool(*record.manifest);
+                const auto actions = externalToolActions(*record.manifest);
+                for (std::size_t i = 0; i < actions.size(); ++i) {
+                    ImGui::SameLine();
+                    const std::string button_label = record.manifest->menus.empty()
+                                                         ? "Run##" + record.manifest->id
+                                                         : actions[i].label + "##" +
+                                                               record.manifest->id + "-" +
+                                                               std::to_string(i);
+                    if (ImGui::Button(button_label.c_str()))
+                        runExternalTool(*record.manifest, actions[i].label);
+                }
             }
 
             if (!record.issues.empty()) {
@@ -1014,13 +1035,9 @@ void RfSimulatorApp::draw_ui() {
             for (const auto *tool : m_extension_manager.externalTools()) {
                 if (!tool)
                     continue;
-                if (tool->menus.empty()) {
-                    if (ImGui::MenuItem(tool->name.c_str()))
-                        runExternalTool(*tool);
-                }
-                for (const auto &menu : tool->menus) {
-                    if (menu.location == "tools" && ImGui::MenuItem(menu.label.c_str()))
-                        runExternalTool(*tool);
+                for (const auto &action : externalToolActions(*tool)) {
+                    if (action.location == "tools" && ImGui::MenuItem(action.label.c_str()))
+                        runExternalTool(*tool, action.label);
                 }
             }
             ImGui::EndMenu();

--- a/app/src/extension_manager.cpp
+++ b/app/src/extension_manager.cpp
@@ -125,17 +125,20 @@ void ExtensionManager::loadRoot(const fs::path &root) {
         const fs::directory_iterator end;
         while (it != end) {
             const fs::directory_entry entry = *it;
-            it.increment(ec);
-            if (ec)
-                return;
 
             std::error_code entry_ec;
-            if (!entry.is_directory(entry_ec) || entry_ec)
-                continue;
+            if (entry.is_directory(entry_ec) && !entry_ec) {
+                const fs::path manifest_path = entry.path() / "plugin.json";
+                if (fs::exists(manifest_path, entry_ec) && !entry_ec)
+                    manifest_paths.push_back(manifest_path);
+            }
 
-            const fs::path manifest_path = entry.path() / "plugin.json";
-            if (fs::exists(manifest_path, entry_ec) && !entry_ec)
-                manifest_paths.push_back(manifest_path);
+            it.increment(ec);
+            if (ec) {
+                ec.clear();
+                if (it == end)
+                    break;
+            }
         }
 
         std::sort(manifest_paths.begin(), manifest_paths.end());

--- a/app/src/extension_manager.cpp
+++ b/app/src/extension_manager.cpp
@@ -4,7 +4,10 @@
 #include <charconv>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <string_view>
+
+#include <nlohmann/json.hpp>
 
 namespace fs = std::filesystem;
 
@@ -57,6 +60,24 @@ ExtensionStatusKind statusForManifest(const ExtensionManifest &manifest) {
         ExtensionStatusKind::Incompatible : ExtensionStatusKind::Ok;
 }
 
+std::optional<std::string> readManifestId(const fs::path &manifest_path) {
+    std::ifstream in(manifest_path);
+    if (!in)
+        return std::nullopt;
+
+    const nlohmann::json j = nlohmann::json::parse(in, nullptr, false);
+    if (j.is_discarded() || !j.is_object())
+        return std::nullopt;
+    if (!j.contains("id") || !j["id"].is_string())
+        return std::nullopt;
+
+    const std::string id = j["id"].get<std::string>();
+    if (id.empty())
+        return std::nullopt;
+
+    return id;
+}
+
 } // namespace
 
 std::vector<fs::path> ExtensionManager::scanRoots(const fs::path &project_root) const {
@@ -95,12 +116,27 @@ void ExtensionManager::loadRoot(const fs::path &root) {
         record.manifest = parseExtensionManifest(manifest_path, record.issues);
         if (record.manifest)
             record.status = statusForManifest(*record.manifest);
+
+        const std::optional<std::string> extension_id =
+            record.manifest ? std::optional<std::string>(record.manifest->id)
+                            : readManifestId(manifest_path);
+
+        if (extension_id) {
+            const auto existing = m_records_by_id.find(*extension_id);
+            if (existing != m_records_by_id.end()) {
+                m_records[existing->second] = std::move(record);
+                continue;
+            }
+            m_records_by_id.emplace(*extension_id, m_records.size());
+        }
+
         m_records.push_back(std::move(record));
     }
 }
 
 void ExtensionManager::rescan(const fs::path &project_root) {
     m_records.clear();
+    m_records_by_id.clear();
     for (const auto &root : scanRoots(project_root))
         loadRoot(root);
 }
@@ -108,8 +144,10 @@ void ExtensionManager::rescan(const fs::path &project_root) {
 std::vector<const ExtensionManifest *> ExtensionManager::dataPacks() const {
     std::vector<const ExtensionManifest *> result;
     for (const auto &record : m_records) {
-        if (record.manifest && record.manifest->kind == ExtensionKind::DataPack)
+        if (record.status == ExtensionStatusKind::Ok && record.manifest &&
+            record.manifest->kind == ExtensionKind::DataPack) {
             result.push_back(&*record.manifest);
+        }
     }
     return result;
 }
@@ -117,8 +155,10 @@ std::vector<const ExtensionManifest *> ExtensionManager::dataPacks() const {
 std::vector<const ExtensionManifest *> ExtensionManager::externalTools() const {
     std::vector<const ExtensionManifest *> result;
     for (const auto &record : m_records) {
-        if (record.manifest && record.manifest->kind == ExtensionKind::ExternalTool)
+        if (record.status == ExtensionStatusKind::Ok && record.manifest &&
+            record.manifest->kind == ExtensionKind::ExternalTool) {
             result.push_back(&*record.manifest);
+        }
     }
     return result;
 }

--- a/app/src/extension_manager.cpp
+++ b/app/src/extension_manager.cpp
@@ -13,37 +13,51 @@ namespace fs = std::filesystem;
 
 namespace {
 
-int parseVersionPart(std::string_view part) {
+std::optional<int> parseVersionPart(std::string_view part) {
+    if (part.empty())
+        return std::nullopt;
+
     int value = 0;
     const auto *begin = part.data();
     const auto *end = part.data() + part.size();
     const auto [ptr, ec] = std::from_chars(begin, end, value);
     if (ec != std::errc{} || ptr != end)
-        return 0;
+        return std::nullopt;
     return value;
 }
 
-std::vector<int> parseVersion(std::string_view version) {
+std::optional<std::vector<int>> parseVersion(std::string_view version) {
+    if (version.empty())
+        return std::nullopt;
+
     std::vector<int> parts;
     std::size_t start = 0;
     while (start <= version.size()) {
         const std::size_t dot = version.find('.', start);
         const std::size_t count = dot == std::string_view::npos ? version.size() - start : dot - start;
-        parts.push_back(parseVersionPart(version.substr(start, count)));
+        const auto part = parseVersionPart(version.substr(start, count));
+        if (!part)
+            return std::nullopt;
+        parts.push_back(*part);
         if (dot == std::string_view::npos)
             break;
         start = dot + 1;
+        if (start == version.size())
+            return std::nullopt;
     }
     return parts;
 }
 
-int compareVersions(std::string_view lhs, std::string_view rhs) {
+std::optional<int> compareVersions(std::string_view lhs, std::string_view rhs) {
     const auto lhs_parts = parseVersion(lhs);
     const auto rhs_parts = parseVersion(rhs);
-    const std::size_t count = std::max(lhs_parts.size(), rhs_parts.size());
+    if (!lhs_parts || !rhs_parts)
+        return std::nullopt;
+
+    const std::size_t count = std::max(lhs_parts->size(), rhs_parts->size());
     for (std::size_t i = 0; i < count; ++i) {
-        const int a = i < lhs_parts.size() ? lhs_parts[i] : 0;
-        const int b = i < rhs_parts.size() ? rhs_parts[i] : 0;
+        const int a = i < lhs_parts->size() ? (*lhs_parts)[i] : 0;
+        const int b = i < rhs_parts->size() ? (*rhs_parts)[i] : 0;
         if (a < b)
             return -1;
         if (a > b)
@@ -56,8 +70,11 @@ ExtensionStatusKind statusForManifest(const ExtensionManifest &manifest) {
     if (manifest.min_app_version.empty())
         return ExtensionStatusKind::Ok;
 
-    return compareVersions(manifest.min_app_version, APP_VERSION) > 0 ?
-        ExtensionStatusKind::Incompatible : ExtensionStatusKind::Ok;
+    const auto compat = compareVersions(manifest.min_app_version, APP_VERSION);
+    if (!compat)
+        return ExtensionStatusKind::Incompatible;
+
+    return *compat > 0 ? ExtensionStatusKind::Incompatible : ExtensionStatusKind::Ok;
 }
 
 std::optional<std::string> readManifestId(const fs::path &manifest_path) {
@@ -95,42 +112,58 @@ std::vector<fs::path> ExtensionManager::scanRoots(const fs::path &project_root) 
 }
 
 void ExtensionManager::loadRoot(const fs::path &root) {
-    if (!fs::exists(root) || !fs::is_directory(root))
-        return;
+    try {
+        std::error_code ec;
+        if (!fs::exists(root, ec) || !fs::is_directory(root, ec))
+            return;
 
-    std::vector<fs::path> manifest_paths;
-    for (const auto &entry : fs::directory_iterator(root)) {
-        if (!entry.is_directory())
-            continue;
+        std::vector<fs::path> manifest_paths;
+        fs::directory_iterator it(root, fs::directory_options::skip_permission_denied, ec);
+        if (ec)
+            return;
 
-        const fs::path manifest_path = entry.path() / "plugin.json";
-        if (fs::exists(manifest_path))
-            manifest_paths.push_back(manifest_path);
-    }
+        const fs::directory_iterator end;
+        while (it != end) {
+            const fs::directory_entry entry = *it;
+            it.increment(ec);
+            if (ec)
+                return;
 
-    std::sort(manifest_paths.begin(), manifest_paths.end());
-
-    for (const auto &manifest_path : manifest_paths) {
-        ExtensionRecord record;
-        record.manifest_path = manifest_path;
-        record.manifest = parseExtensionManifest(manifest_path, record.issues);
-        if (record.manifest)
-            record.status = statusForManifest(*record.manifest);
-
-        const std::optional<std::string> extension_id =
-            record.manifest ? std::optional<std::string>(record.manifest->id)
-                            : readManifestId(manifest_path);
-
-        if (extension_id) {
-            const auto existing = m_records_by_id.find(*extension_id);
-            if (existing != m_records_by_id.end()) {
-                m_records[existing->second] = std::move(record);
+            std::error_code entry_ec;
+            if (!entry.is_directory(entry_ec) || entry_ec)
                 continue;
-            }
-            m_records_by_id.emplace(*extension_id, m_records.size());
+
+            const fs::path manifest_path = entry.path() / "plugin.json";
+            if (fs::exists(manifest_path, entry_ec) && !entry_ec)
+                manifest_paths.push_back(manifest_path);
         }
 
-        m_records.push_back(std::move(record));
+        std::sort(manifest_paths.begin(), manifest_paths.end());
+
+        for (const auto &manifest_path : manifest_paths) {
+            ExtensionRecord record;
+            record.manifest_path = manifest_path;
+            record.manifest = parseExtensionManifest(manifest_path, record.issues);
+            if (record.manifest)
+                record.status = statusForManifest(*record.manifest);
+
+            const std::optional<std::string> extension_id =
+                record.manifest ? std::optional<std::string>(record.manifest->id)
+                                : readManifestId(manifest_path);
+
+            if (extension_id) {
+                const auto existing = m_records_by_id.find(*extension_id);
+                if (existing != m_records_by_id.end()) {
+                    m_records[existing->second] = std::move(record);
+                    continue;
+                }
+                m_records_by_id.emplace(*extension_id, m_records.size());
+            }
+
+            m_records.push_back(std::move(record));
+        }
+    } catch (const fs::filesystem_error &) {
+        return;
     }
 }
 

--- a/app/src/extension_manager.cpp
+++ b/app/src/extension_manager.cpp
@@ -1,0 +1,124 @@
+#include "extension_manager.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cstdlib>
+#include <filesystem>
+#include <string_view>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+int parseVersionPart(std::string_view part) {
+    int value = 0;
+    const auto *begin = part.data();
+    const auto *end = part.data() + part.size();
+    const auto [ptr, ec] = std::from_chars(begin, end, value);
+    if (ec != std::errc{} || ptr != end)
+        return 0;
+    return value;
+}
+
+std::vector<int> parseVersion(std::string_view version) {
+    std::vector<int> parts;
+    std::size_t start = 0;
+    while (start <= version.size()) {
+        const std::size_t dot = version.find('.', start);
+        const std::size_t count = dot == std::string_view::npos ? version.size() - start : dot - start;
+        parts.push_back(parseVersionPart(version.substr(start, count)));
+        if (dot == std::string_view::npos)
+            break;
+        start = dot + 1;
+    }
+    return parts;
+}
+
+int compareVersions(std::string_view lhs, std::string_view rhs) {
+    const auto lhs_parts = parseVersion(lhs);
+    const auto rhs_parts = parseVersion(rhs);
+    const std::size_t count = std::max(lhs_parts.size(), rhs_parts.size());
+    for (std::size_t i = 0; i < count; ++i) {
+        const int a = i < lhs_parts.size() ? lhs_parts[i] : 0;
+        const int b = i < rhs_parts.size() ? rhs_parts[i] : 0;
+        if (a < b)
+            return -1;
+        if (a > b)
+            return 1;
+    }
+    return 0;
+}
+
+ExtensionStatusKind statusForManifest(const ExtensionManifest &manifest) {
+    if (manifest.min_app_version.empty())
+        return ExtensionStatusKind::Ok;
+
+    return compareVersions(manifest.min_app_version, APP_VERSION) > 0 ?
+        ExtensionStatusKind::Incompatible : ExtensionStatusKind::Ok;
+}
+
+} // namespace
+
+std::vector<fs::path> ExtensionManager::scanRoots(const fs::path &project_root) const {
+    std::vector<fs::path> roots;
+    roots.push_back(fs::path(PROJECT_SOURCE_DIR) / "extensions");
+#ifdef _WIN32
+    if (const char *home = std::getenv("USERPROFILE"))
+        roots.push_back(fs::path(home) / ".rf-sim" / "extensions");
+#else
+    if (const char *home = std::getenv("HOME"))
+        roots.push_back(fs::path(home) / ".rf-sim" / "extensions");
+#endif
+    roots.push_back(project_root / "rf-sim-extensions");
+    return roots;
+}
+
+void ExtensionManager::loadRoot(const fs::path &root) {
+    if (!fs::exists(root) || !fs::is_directory(root))
+        return;
+
+    std::vector<fs::path> manifest_paths;
+    for (const auto &entry : fs::directory_iterator(root)) {
+        if (!entry.is_directory())
+            continue;
+
+        const fs::path manifest_path = entry.path() / "plugin.json";
+        if (fs::exists(manifest_path))
+            manifest_paths.push_back(manifest_path);
+    }
+
+    std::sort(manifest_paths.begin(), manifest_paths.end());
+
+    for (const auto &manifest_path : manifest_paths) {
+        ExtensionRecord record;
+        record.manifest_path = manifest_path;
+        record.manifest = parseExtensionManifest(manifest_path, record.issues);
+        if (record.manifest)
+            record.status = statusForManifest(*record.manifest);
+        m_records.push_back(std::move(record));
+    }
+}
+
+void ExtensionManager::rescan(const fs::path &project_root) {
+    m_records.clear();
+    for (const auto &root : scanRoots(project_root))
+        loadRoot(root);
+}
+
+std::vector<const ExtensionManifest *> ExtensionManager::dataPacks() const {
+    std::vector<const ExtensionManifest *> result;
+    for (const auto &record : m_records) {
+        if (record.manifest && record.manifest->kind == ExtensionKind::DataPack)
+            result.push_back(&*record.manifest);
+    }
+    return result;
+}
+
+std::vector<const ExtensionManifest *> ExtensionManager::externalTools() const {
+    std::vector<const ExtensionManifest *> result;
+    for (const auto &record : m_records) {
+        if (record.manifest && record.manifest->kind == ExtensionKind::ExternalTool)
+            result.push_back(&*record.manifest);
+    }
+    return result;
+}

--- a/app/src/extension_manager.cpp
+++ b/app/src/extension_manager.cpp
@@ -34,7 +34,8 @@ std::optional<std::vector<int>> parseVersion(std::string_view version) {
     std::size_t start = 0;
     while (start <= version.size()) {
         const std::size_t dot = version.find('.', start);
-        const std::size_t count = dot == std::string_view::npos ? version.size() - start : dot - start;
+        const std::size_t count =
+            dot == std::string_view::npos ? version.size() - start : dot - start;
         const auto part = parseVersionPart(version.substr(start, count));
         if (!part)
             return std::nullopt;

--- a/app/src/extension_manifest.cpp
+++ b/app/src/extension_manifest.cpp
@@ -11,7 +11,8 @@ using json = nlohmann::json;
 
 namespace {
 
-void addIssue(std::vector<ExtensionValidationIssue> &issues, std::string field, std::string message) {
+void addIssue(std::vector<ExtensionValidationIssue> &issues, std::string field,
+              std::string message) {
     issues.push_back({std::move(field), std::move(message)});
 }
 
@@ -44,11 +45,8 @@ bool pathWithinRoot(const fs::path &root, const fs::path &candidate) {
     return true;
 }
 
-bool resolveWithinRoot(const fs::path &root,
-                       const fs::path &input,
-                       fs::path &resolved,
-                       std::vector<ExtensionValidationIssue> &issues,
-                       const std::string &field) {
+bool resolveWithinRoot(const fs::path &root, const fs::path &input, fs::path &resolved,
+                       std::vector<ExtensionValidationIssue> &issues, const std::string &field) {
     if (input.empty()) {
         addIssue(issues, field, "Path must not be empty");
         return false;
@@ -116,17 +114,15 @@ bool parseMenus(const json &value, std::vector<ExtensionMenuEntry> &menus,
             continue;
         }
 
-        menus.push_back({entry["location"].get<std::string>(), entry["label"].get<std::string>()});
+        const std::string location = entry["location"].get<std::string>();
+        menus.push_back({location, entry["label"].get<std::string>()});
     }
 
     return true;
 }
 
-bool parsePathList(const json &value,
-                   const fs::path &root,
-                   std::vector<fs::path> &paths,
-                   std::vector<ExtensionValidationIssue> &issues,
-                   const std::string &field) {
+bool parsePathList(const json &value, const fs::path &root, std::vector<fs::path> &paths,
+                   std::vector<ExtensionValidationIssue> &issues, const std::string &field) {
     if (value.is_null())
         return true;
     if (!value.is_array()) {
@@ -153,9 +149,9 @@ bool parsePathList(const json &value,
 
 } // namespace
 
-std::optional<ExtensionManifest> parseExtensionManifest(
-    const fs::path &manifest_path,
-    std::vector<ExtensionValidationIssue> &issues) {
+std::optional<ExtensionManifest>
+parseExtensionManifest(const fs::path &manifest_path,
+                       std::vector<ExtensionValidationIssue> &issues) {
     std::error_code ec;
     const fs::path canonical_manifest_path = fs::weakly_canonical(manifest_path, ec);
     if (ec) {

--- a/app/src/extension_manifest.cpp
+++ b/app/src/extension_manifest.cpp
@@ -1,6 +1,7 @@
 #include "extension_manifest.h"
 
 #include <fstream>
+#include <limits>
 #include <system_error>
 
 #include <nlohmann/json.hpp>
@@ -12,6 +13,14 @@ namespace {
 
 void addIssue(std::vector<ExtensionValidationIssue> &issues, std::string field, std::string message) {
     issues.push_back({std::move(field), std::move(message)});
+}
+
+bool containsParentTraversal(const fs::path &path) {
+    for (const auto &part : path) {
+        if (part == "..")
+            return true;
+    }
+    return false;
 }
 
 bool pathWithinRoot(const fs::path &root, const fs::path &candidate) {
@@ -42,6 +51,11 @@ bool resolveWithinRoot(const fs::path &root,
                        const std::string &field) {
     if (input.empty()) {
         addIssue(issues, field, "Path must not be empty");
+        return false;
+    }
+
+    if (containsParentTraversal(input)) {
+        addIssue(issues, field, "Path must not contain '..'");
         return false;
     }
 
@@ -168,9 +182,34 @@ std::optional<ExtensionManifest> parseExtensionManifest(
     if (!j.contains("schema_version") || !j["schema_version"].is_number_integer()) {
         addIssue(issues, "schema_version", "Expected an integer");
     } else {
-        manifest.schema_version = j["schema_version"].get<int>();
-        if (manifest.schema_version != 1)
-            addIssue(issues, "schema_version", "Only schema_version=1 is supported");
+        const auto &schema_version_json = j["schema_version"];
+        int schema_version_value = 0;
+        bool schema_version_in_range = true;
+
+        if (schema_version_json.is_number_unsigned()) {
+            const auto raw = schema_version_json.get<unsigned long long>();
+            if (raw > static_cast<unsigned long long>(std::numeric_limits<int>::max())) {
+                addIssue(issues, "schema_version", "Integer value is out of range");
+                schema_version_in_range = false;
+            } else {
+                schema_version_value = static_cast<int>(raw);
+            }
+        } else {
+            const auto raw = schema_version_json.get<long long>();
+            if (raw < static_cast<long long>(std::numeric_limits<int>::min()) ||
+                raw > static_cast<long long>(std::numeric_limits<int>::max())) {
+                addIssue(issues, "schema_version", "Integer value is out of range");
+                schema_version_in_range = false;
+            } else {
+                schema_version_value = static_cast<int>(raw);
+            }
+        }
+
+        if (schema_version_in_range) {
+            manifest.schema_version = schema_version_value;
+            if (manifest.schema_version != 1)
+                addIssue(issues, "schema_version", "Only schema_version=1 is supported");
+        }
     }
 
     auto readRequiredString = [&](const char *field, std::string &out) {

--- a/app/src/extension_manifest.cpp
+++ b/app/src/extension_manifest.cpp
@@ -1,0 +1,270 @@
+#include "extension_manifest.h"
+
+#include <fstream>
+#include <system_error>
+
+#include <nlohmann/json.hpp>
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+
+namespace {
+
+void addIssue(std::vector<ExtensionValidationIssue> &issues, std::string field, std::string message) {
+    issues.push_back({std::move(field), std::move(message)});
+}
+
+bool pathWithinRoot(const fs::path &root, const fs::path &candidate) {
+    std::error_code ec;
+    const fs::path canonical_root = fs::weakly_canonical(root, ec);
+    if (ec)
+        return false;
+
+    ec.clear();
+    const fs::path canonical_candidate = fs::weakly_canonical(candidate, ec);
+    if (ec)
+        return false;
+
+    auto root_it = canonical_root.begin();
+    auto candidate_it = canonical_candidate.begin();
+    for (; root_it != canonical_root.end(); ++root_it, ++candidate_it) {
+        if (candidate_it == canonical_candidate.end() || *root_it != *candidate_it)
+            return false;
+    }
+
+    return true;
+}
+
+bool resolveWithinRoot(const fs::path &root,
+                       const fs::path &input,
+                       fs::path &resolved,
+                       std::vector<ExtensionValidationIssue> &issues,
+                       const std::string &field) {
+    if (input.empty()) {
+        addIssue(issues, field, "Path must not be empty");
+        return false;
+    }
+
+    fs::path candidate = input.is_absolute() ? input : (root / input);
+    if (!pathWithinRoot(root, candidate)) {
+        addIssue(issues, field, "Path must stay within the extension root");
+        return false;
+    }
+
+    std::error_code ec;
+    resolved = fs::weakly_canonical(candidate, ec);
+    if (ec) {
+        addIssue(issues, field, "Path could not be resolved");
+        return false;
+    }
+
+    return true;
+}
+
+bool parseCapability(const json &value, ExtensionCapability &out) {
+    if (!value.is_string())
+        return false;
+
+    const std::string name = value.get<std::string>();
+    if (name == "generator") {
+        out = ExtensionCapability::Generator;
+        return true;
+    }
+    if (name == "importer") {
+        out = ExtensionCapability::Importer;
+        return true;
+    }
+    return false;
+}
+
+bool parseMenus(const json &value, std::vector<ExtensionMenuEntry> &menus,
+                std::vector<ExtensionValidationIssue> &issues) {
+    if (value.is_null())
+        return true;
+    if (!value.is_array()) {
+        addIssue(issues, "menus", "Expected an array");
+        return false;
+    }
+
+    for (std::size_t i = 0; i < value.size(); ++i) {
+        const auto &entry = value[i];
+        if (!entry.is_object()) {
+            addIssue(issues, "menus[" + std::to_string(i) + "]", "Expected an object");
+            continue;
+        }
+
+        if (!entry.contains("location") || !entry["location"].is_string()) {
+            addIssue(issues, "menus[" + std::to_string(i) + "].location", "Expected a string");
+            continue;
+        }
+        if (!entry.contains("label") || !entry["label"].is_string()) {
+            addIssue(issues, "menus[" + std::to_string(i) + "].label", "Expected a string");
+            continue;
+        }
+
+        menus.push_back({entry["location"].get<std::string>(), entry["label"].get<std::string>()});
+    }
+
+    return true;
+}
+
+bool parsePathList(const json &value,
+                   const fs::path &root,
+                   std::vector<fs::path> &paths,
+                   std::vector<ExtensionValidationIssue> &issues,
+                   const std::string &field) {
+    if (value.is_null())
+        return true;
+    if (!value.is_array()) {
+        addIssue(issues, field, "Expected an array");
+        return false;
+    }
+
+    for (std::size_t i = 0; i < value.size(); ++i) {
+        const auto &item = value[i];
+        if (!item.is_string()) {
+            addIssue(issues, field + "[" + std::to_string(i) + "]", "Expected a string");
+            continue;
+        }
+
+        fs::path resolved;
+        if (resolveWithinRoot(root, fs::path(item.get<std::string>()), resolved, issues,
+                              field + "[" + std::to_string(i) + "]")) {
+            paths.push_back(std::move(resolved));
+        }
+    }
+
+    return true;
+}
+
+} // namespace
+
+std::optional<ExtensionManifest> parseExtensionManifest(
+    const fs::path &manifest_path,
+    std::vector<ExtensionValidationIssue> &issues) {
+    std::error_code ec;
+    const fs::path canonical_manifest_path = fs::weakly_canonical(manifest_path, ec);
+    if (ec) {
+        addIssue(issues, "manifest", "Could not resolve manifest path");
+        return std::nullopt;
+    }
+
+    std::ifstream in(canonical_manifest_path);
+    if (!in) {
+        addIssue(issues, "manifest", "Could not open manifest file");
+        return std::nullopt;
+    }
+
+    json j = json::parse(in, nullptr, false);
+    if (j.is_discarded() || !j.is_object()) {
+        addIssue(issues, "manifest", "Invalid JSON object");
+        return std::nullopt;
+    }
+
+    ExtensionManifest manifest;
+    manifest.manifest_path = canonical_manifest_path;
+    manifest.root_dir = canonical_manifest_path.parent_path();
+
+    if (!j.contains("schema_version") || !j["schema_version"].is_number_integer()) {
+        addIssue(issues, "schema_version", "Expected an integer");
+    } else {
+        manifest.schema_version = j["schema_version"].get<int>();
+        if (manifest.schema_version != 1)
+            addIssue(issues, "schema_version", "Only schema_version=1 is supported");
+    }
+
+    auto readRequiredString = [&](const char *field, std::string &out) {
+        if (!j.contains(field) || !j[field].is_string()) {
+            addIssue(issues, field, "Expected a string");
+            return;
+        }
+        out = j[field].get<std::string>();
+        if (out.empty())
+            addIssue(issues, field, "Must not be empty");
+    };
+
+    readRequiredString("id", manifest.id);
+    readRequiredString("name", manifest.name);
+    readRequiredString("version", manifest.version);
+
+    if (j.contains("description") && j["description"].is_string())
+        manifest.description = j["description"].get<std::string>();
+    else if (j.contains("description"))
+        addIssue(issues, "description", "Expected a string");
+
+    if (j.contains("author") && j["author"].is_string())
+        manifest.author = j["author"].get<std::string>();
+    else if (j.contains("author"))
+        addIssue(issues, "author", "Expected a string");
+
+    if (j.contains("compat")) {
+        if (!j["compat"].is_object()) {
+            addIssue(issues, "compat", "Expected an object");
+        } else if (j["compat"].contains("min_app_version")) {
+            if (!j["compat"]["min_app_version"].is_string()) {
+                addIssue(issues, "compat.min_app_version", "Expected a string");
+            } else {
+                manifest.min_app_version = j["compat"]["min_app_version"].get<std::string>();
+            }
+        }
+    }
+
+    std::string kind_value;
+    if (!j.contains("kind") || !j["kind"].is_string()) {
+        addIssue(issues, "kind", "Expected 'data-pack' or 'external-tool'");
+    } else {
+        kind_value = j["kind"].get<std::string>();
+        if (kind_value == "data-pack") {
+            manifest.kind = ExtensionKind::DataPack;
+        } else if (kind_value == "external-tool") {
+            manifest.kind = ExtensionKind::ExternalTool;
+        } else {
+            addIssue(issues, "kind", "Expected 'data-pack' or 'external-tool'");
+        }
+    }
+
+    if (j.contains("capabilities")) {
+        if (!j["capabilities"].is_array()) {
+            addIssue(issues, "capabilities", "Expected an array");
+        } else {
+            for (std::size_t i = 0; i < j["capabilities"].size(); ++i) {
+                ExtensionCapability capability{};
+                if (!parseCapability(j["capabilities"][i], capability)) {
+                    addIssue(issues, "capabilities[" + std::to_string(i) + "]",
+                             "Expected 'generator' or 'importer'");
+                } else {
+                    manifest.capabilities.push_back(capability);
+                }
+            }
+        }
+    }
+
+    if (j.contains("menus"))
+        parseMenus(j["menus"], manifest.menus, issues);
+
+    if (j.contains("library_roots"))
+        parsePathList(j["library_roots"], manifest.root_dir, manifest.library_roots, issues,
+                      "library_roots");
+    if (j.contains("data_roots"))
+        parsePathList(j["data_roots"], manifest.root_dir, manifest.data_roots, issues,
+                      "data_roots");
+
+    if (j.contains("entry")) {
+        if (!j["entry"].is_string()) {
+            addIssue(issues, "entry", "Expected a string");
+        } else {
+            fs::path resolved_entry;
+            if (resolveWithinRoot(manifest.root_dir, fs::path(j["entry"].get<std::string>()),
+                                  resolved_entry, issues, "entry")) {
+                manifest.entry_path = std::move(resolved_entry);
+            }
+        }
+    } else if (manifest.kind == ExtensionKind::ExternalTool) {
+        addIssue(issues, "entry", "Required for external-tool manifests");
+    }
+
+    if (!issues.empty())
+        return std::nullopt;
+
+    return manifest;
+}

--- a/app/src/external_tool_runner.cpp
+++ b/app/src/external_tool_runner.cpp
@@ -1,0 +1,352 @@
+#include "external_tool_runner.h"
+
+#include <chrono>
+#include <fstream>
+#include <sstream>
+#include <system_error>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+namespace {
+
+using json = nlohmann::json;
+constexpr auto kProcessTimeout = std::chrono::seconds(30);
+
+struct ProcessResult {
+    bool launched = false;
+    int exit_code = -1;
+    std::string error;
+};
+
+fs::path makeWorkDir(const fs::path &requested) {
+    if (!requested.empty())
+        return requested;
+
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    return fs::temp_directory_path() / ("rfsim_external_tool_" + std::to_string(stamp));
+}
+
+std::string manifestKindToString(const ExtensionManifest &manifest) {
+    return manifest.kind == ExtensionKind::ExternalTool ? "external-tool" : "data-pack";
+}
+
+json buildRequestJson(const ExtensionManifest &manifest, const ExternalToolRequest &request,
+                      const fs::path &request_path) {
+    return json{{"contract_version", request.contract_version},
+                {"action_label", request.action_label},
+                {"project_root", request.project_root.generic_string()},
+                {"selected_path", request.selected_path.generic_string()},
+                {"work_dir", request_path.parent_path().generic_string()},
+                {"request_path", request_path.generic_string()},
+                {"result_path", request.result_path.generic_string()},
+                {"manifest",
+                 {{"id", manifest.id},
+                  {"name", manifest.name},
+                  {"version", manifest.version},
+                  {"kind", manifestKindToString(manifest)},
+                  {"entry_path", manifest.entry_path.generic_string()},
+                  {"root_dir", manifest.root_dir.generic_string()}}}};
+}
+
+bool writeJsonFile(const fs::path &path, const json &value, std::string &error) {
+    std::error_code ec;
+    if (!path.parent_path().empty())
+        fs::create_directories(path.parent_path(), ec);
+    if (ec) {
+        error = "could not create output directory";
+        return false;
+    }
+
+    std::ofstream out(path);
+    if (!out) {
+        error = "could not open output file";
+        return false;
+    }
+
+    out << value.dump(2) << '\n';
+    if (!out.good()) {
+        error = "could not write output file";
+        return false;
+    }
+
+    return true;
+}
+
+#ifdef _WIN32
+std::wstring quoteWindowsArg(const std::wstring &arg) {
+    if (arg.empty())
+        return L"\"\"";
+
+    const bool needs_quotes = arg.find_first_of(L" \t\"") != std::wstring::npos;
+    if (!needs_quotes)
+        return arg;
+
+    std::wstring quoted = L"\"";
+    std::size_t backslashes = 0;
+    for (const wchar_t ch : arg) {
+        if (ch == L'\\') {
+            ++backslashes;
+            continue;
+        }
+
+        if (ch == L'\"') {
+            quoted.append(backslashes * 2 + 1, L'\\');
+            quoted.push_back(L'\"');
+            backslashes = 0;
+            continue;
+        }
+
+        quoted.append(backslashes, L'\\');
+        backslashes = 0;
+        quoted.push_back(ch);
+    }
+
+    quoted.append(backslashes * 2, L'\\');
+    quoted.push_back(L'\"');
+    return quoted;
+}
+
+std::wstring buildCommandLine(const std::vector<fs::path> &argv) {
+    std::wstring command_line;
+    for (std::size_t i = 0; i < argv.size(); ++i) {
+        if (i != 0)
+            command_line.push_back(L' ');
+        command_line += quoteWindowsArg(argv[i].wstring());
+    }
+    return command_line;
+}
+
+ProcessResult launchProcess(const std::vector<fs::path> &argv, const fs::path &working_dir) {
+    if (argv.empty())
+        return {.launched = false, .exit_code = -1, .error = "empty argv"};
+
+    std::wstring command_line = buildCommandLine(argv);
+    std::wstring working_dir_w;
+    if (!working_dir.empty())
+        working_dir_w = working_dir.wstring();
+
+    STARTUPINFOW startup_info{};
+    startup_info.cb = sizeof(startup_info);
+    PROCESS_INFORMATION process_info{};
+
+    const BOOL created = CreateProcessW(
+        nullptr, command_line.data(), nullptr, nullptr, FALSE, 0, nullptr,
+        working_dir.empty() ? nullptr : working_dir_w.c_str(), &startup_info, &process_info);
+    if (!created)
+        return {.launched = false, .exit_code = -1, .error = "CreateProcessW failed"};
+
+    const auto deadline = std::chrono::steady_clock::now() + kProcessTimeout;
+    while (true) {
+        const DWORD wait = WaitForSingleObject(process_info.hProcess, 100);
+        if (wait == WAIT_OBJECT_0)
+            break;
+        if (wait != WAIT_TIMEOUT) {
+            CloseHandle(process_info.hThread);
+            CloseHandle(process_info.hProcess);
+            return {.launched = true, .exit_code = -1, .error = "WaitForSingleObject failed"};
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            TerminateProcess(process_info.hProcess, 124);
+            WaitForSingleObject(process_info.hProcess, INFINITE);
+            CloseHandle(process_info.hThread);
+            CloseHandle(process_info.hProcess);
+            return {.launched = true, .exit_code = 124, .error = "process timed out"};
+        }
+    }
+
+    DWORD exit_code = 0;
+    if (!GetExitCodeProcess(process_info.hProcess, &exit_code)) {
+        CloseHandle(process_info.hThread);
+        CloseHandle(process_info.hProcess);
+        return {.launched = true, .exit_code = -1, .error = "GetExitCodeProcess failed"};
+    }
+
+    CloseHandle(process_info.hThread);
+    CloseHandle(process_info.hProcess);
+    return {.launched = true, .exit_code = static_cast<int>(exit_code), .error = {}};
+}
+#else
+ProcessResult launchProcess(const std::vector<fs::path> &argv, const fs::path &working_dir) {
+    if (argv.empty())
+        return {.launched = false, .exit_code = -1, .error = "empty argv"};
+
+    const pid_t pid = fork();
+    if (pid < 0)
+        return {.launched = false, .exit_code = -1, .error = "fork failed"};
+
+    if (pid == 0) {
+        if (!working_dir.empty() && chdir(working_dir.c_str()) != 0)
+            _exit(127);
+
+        std::vector<std::string> storage;
+        storage.reserve(argv.size());
+        for (const auto &arg : argv)
+            storage.push_back(arg.string());
+
+        std::vector<char *> cargv;
+        cargv.reserve(storage.size() + 1);
+        for (auto &arg : storage)
+            cargv.push_back(arg.data());
+        cargv.push_back(nullptr);
+
+        execvp(cargv.front(), cargv.data());
+        _exit(127);
+    }
+
+    const auto deadline = std::chrono::steady_clock::now() + kProcessTimeout;
+    int status = 0;
+    while (true) {
+        const pid_t wait_result = waitpid(pid, &status, WNOHANG);
+        if (wait_result == pid)
+            break;
+        if (wait_result < 0)
+            return {.launched = true, .exit_code = -1, .error = "waitpid failed"};
+        if (wait_result == 0) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                kill(pid, SIGKILL);
+                waitpid(pid, &status, 0);
+                return {.launched = true, .exit_code = 124, .error = "process timed out"};
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    }
+
+    if (WIFEXITED(status))
+        return {.launched = true, .exit_code = WEXITSTATUS(status), .error = {}};
+    if (WIFSIGNALED(status))
+        return {.launched = true,
+                .exit_code = 128 + WTERMSIG(status),
+                .error = "process terminated by signal"};
+
+    return {.launched = true, .exit_code = -1, .error = "process did not exit cleanly"};
+}
+#endif
+
+std::vector<fs::path> buildCommand(const ExtensionManifest &manifest,
+                                   const ExternalToolRequest &request,
+                                   const fs::path &request_path) {
+    std::vector<fs::path> argv;
+#ifdef _WIN32
+    const bool is_python_script = manifest.entry_path.extension() == ".py";
+    if (is_python_script) {
+        argv.emplace_back("python");
+        argv.push_back(manifest.entry_path);
+    } else {
+        argv.push_back(manifest.entry_path);
+    }
+#else
+    const bool is_python_script = manifest.entry_path.extension() == ".py";
+    if (is_python_script) {
+        argv.emplace_back("python3");
+        argv.push_back(manifest.entry_path);
+    } else {
+        argv.push_back(manifest.entry_path);
+    }
+#endif
+    argv.emplace_back("--request");
+    argv.push_back(request_path);
+    argv.emplace_back("--result");
+    argv.push_back(request.result_path);
+    return argv;
+}
+
+std::string readJsonMessage(const fs::path &path) {
+    std::ifstream in(path);
+    if (!in)
+        return {};
+
+    const json value = json::parse(in, nullptr, false);
+    if (value.is_discarded() || !value.is_object())
+        return {};
+
+    if (value.contains("message") && value["message"].is_string())
+        return value["message"].get<std::string>();
+    return "ok";
+}
+
+} // namespace
+
+ExternalToolRunResult ExternalToolRunner::run(const ExtensionManifest &manifest,
+                                              const ExternalToolRequest &request) const {
+    ExternalToolRunResult result;
+    result.result_path = request.result_path;
+    result.work_dir = makeWorkDir(request.work_dir);
+
+    if (manifest.kind != ExtensionKind::ExternalTool) {
+        result.message = "manifest is not an external tool";
+        return result;
+    }
+    if (manifest.entry_path.empty()) {
+        result.message = "entry path is empty";
+        return result;
+    }
+    if (!fs::exists(manifest.entry_path)) {
+        result.message = "entry path does not exist";
+        return result;
+    }
+
+    std::error_code ec;
+    fs::create_directories(result.work_dir, ec);
+    if (ec) {
+        result.message = "could not create work directory";
+        return result;
+    }
+
+    if (!request.result_path.parent_path().empty()) {
+        fs::create_directories(request.result_path.parent_path(), ec);
+        if (ec) {
+            result.message = "could not create result directory";
+            return result;
+        }
+    }
+
+    const fs::path request_path = result.work_dir / "request.json";
+    const json request_json = buildRequestJson(manifest, request, request_path);
+    std::string error;
+    if (!writeJsonFile(request_path, request_json, error)) {
+        result.message = error;
+        return result;
+    }
+
+    const std::vector<fs::path> argv = buildCommand(manifest, request, request_path);
+    const ProcessResult process = launchProcess(argv, result.work_dir);
+    result.exit_code = process.exit_code;
+    if (!process.launched) {
+        result.message = process.error;
+        return result;
+    }
+    if (process.exit_code != 0) {
+        std::ostringstream oss;
+        oss << "external tool exited with code " << process.exit_code;
+        result.message = oss.str();
+        return result;
+    }
+
+    if (!fs::exists(request.result_path)) {
+        result.message = "result file missing";
+        return result;
+    }
+
+    const std::string message = readJsonMessage(request.result_path);
+    if (message.empty()) {
+        result.message = "result file is not valid JSON";
+        return result;
+    }
+
+    result.ok = true;
+    result.message = message;
+    return result;
+}

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -27,7 +27,7 @@ Own the Catch2 v3.4.0 unit test suite and ImGui test engine UI tests. Verify all
 - Test both nominal and edge cases: zero inputs, max values, parameter extremes
 - Node graph tests must verify probe routing, link topology, and topological sort
 - Touchstone parser tests must cover all format variants (DB, MA, RI) and frequency units
-- Do not depend on ImGui or GLFW in test files — engines are pure DSP
+- Do not depend on ImGui or GLFW in pure DSP-engine tests; app-integration tests may create ImGui, ImPlot, and ImNodes contexts to construct `RfSimulatorApp` safely
 - App-level tests may include `simulator::app` for integration scenarios
 
 ## Verification

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,3 +88,11 @@ target_link_libraries(test_component_authoring PRIVATE
 )
 target_compile_definitions(test_component_authoring PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 add_test(NAME test_component_authoring COMMAND test_component_authoring WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_executable(test_extensions test_extensions.cpp)
+target_link_libraries(test_extensions PRIVATE
+    simulator::app
+    Catch2::Catch2WithMain
+)
+target_compile_definitions(test_extensions PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+add_test(NAME test_extensions COMMAND test_extensions WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/tests/fixtures/extensions/echo_tool.py
+++ b/tests/fixtures/extensions/echo_tool.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+
+def main() -> int:
+    request = pathlib.Path(sys.argv[sys.argv.index("--request") + 1])
+    result = pathlib.Path(sys.argv[sys.argv.index("--result") + 1])
+    request_json = json.loads(request.read_text(encoding="utf-8"))
+    result.write_text(
+        json.dumps(
+            {
+                "result_type": "report_created",
+                "message": "tool ok",
+                "request": request_json,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/extensions/noop_tool.py
+++ b/tests/fixtures/extensions/noop_tool.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys
+
+
+def main() -> int:
+    # Intentionally do nothing: the runner should treat missing result.json as failure.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_extensions.cpp
+++ b/tests/test_extensions.cpp
@@ -1,4 +1,7 @@
 #include "extension_manifest.h"
+#include "extension_manager.h"
+
+#include <algorithm>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -92,4 +95,55 @@ TEST_CASE("extension manifest rejects unsupported capability", "[extensions][man
     REQUIRE_FALSE(manifest.has_value());
     REQUIRE_FALSE(issues.empty());
     REQUIRE(issues.front().field == "capabilities[0]");
+}
+
+TEST_CASE("extension manager discovers project-local data packs", "[extensions][discovery]") {
+    ExtensionManager mgr;
+    const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_project";
+    const fs::path manifest_path = writeManifest(
+        project_root / "rf-sim-extensions" / "project-pack",
+        R"json({
+            "schema_version": 1,
+            "id": "project.pack",
+            "name": "Project Pack",
+            "version": "1.0.0",
+            "kind": "data-pack"
+        })json");
+
+    mgr.rescan(project_root);
+
+    const auto &records = mgr.all();
+    const auto record_it =
+        std::find_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
+            return record.manifest_path == manifest_path;
+        });
+
+    REQUIRE(record_it != records.end());
+    REQUIRE(record_it->status == ExtensionStatusKind::Ok);
+    REQUIRE(record_it->manifest.has_value());
+    REQUIRE(record_it->manifest->kind == ExtensionKind::DataPack);
+
+    const auto packs = mgr.dataPacks();
+    REQUIRE(std::find(packs.begin(), packs.end(), &*record_it->manifest) != packs.end());
+}
+
+TEST_CASE("extension manager keeps invalid manifests visible", "[extensions][discovery]") {
+    ExtensionManager mgr;
+    const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_invalid";
+    const fs::path manifest_path = writeManifest(
+        project_root / "rf-sim-extensions" / "bad",
+        R"json({"kind": "external-tool"})json");
+
+    mgr.rescan(project_root);
+
+    const auto &records = mgr.all();
+    const auto record_it =
+        std::find_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
+            return record.manifest_path == manifest_path;
+        });
+
+    REQUIRE(record_it != records.end());
+    REQUIRE(record_it->status == ExtensionStatusKind::Invalid);
+    REQUIRE_FALSE(record_it->manifest.has_value());
+    REQUIRE_FALSE(record_it->issues.empty());
 }

--- a/tests/test_extensions.cpp
+++ b/tests/test_extensions.cpp
@@ -1,5 +1,10 @@
-#include "extension_manifest.h"
+#include "app.h"
 #include "extension_manager.h"
+#include "extension_manifest.h"
+
+#include "external_tool_runner.h"
+
+#include <nlohmann/json.hpp>
 
 #include <algorithm>
 
@@ -8,9 +13,8 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
-#include <vector>
 #include <system_error>
-
+#include <vector>
 
 namespace fs = std::filesystem;
 
@@ -33,14 +37,12 @@ struct ScopedRemove {
     }
 };
 
-
 } // namespace
 
 TEST_CASE("extension manifest parses valid external-tool generator", "[extensions][manifest]") {
     const fs::path root = fs::temp_directory_path() / "rfsim_ext_manifest_ok";
-    const fs::path manifest_path = writeManifest(
-        root,
-        R"json({
+    const fs::path manifest_path = writeManifest(root,
+                                                 R"json({
             "schema_version": 1,
             "id": "vendor.amp-f-generator",
             "name": "AMP_F Generator",
@@ -58,7 +60,8 @@ TEST_CASE("extension manifest parses valid external-tool generator", "[extension
     REQUIRE(manifest.has_value());
     REQUIRE(issues.empty());
     REQUIRE(manifest->kind == ExtensionKind::ExternalTool);
-    REQUIRE(manifest->capabilities == std::vector<ExtensionCapability>{ExtensionCapability::Generator});
+    REQUIRE(manifest->capabilities ==
+            std::vector<ExtensionCapability>{ExtensionCapability::Generator});
     REQUIRE(manifest->entry_path == fs::weakly_canonical(root / "bin/adapter.py"));
     REQUIRE(manifest->menus.size() == 1);
     REQUIRE(manifest->menus.front().location == "tools");
@@ -67,9 +70,8 @@ TEST_CASE("extension manifest parses valid external-tool generator", "[extension
 
 TEST_CASE("extension manifest rejects entry escaping plugin root", "[extensions][manifest]") {
     const fs::path root = fs::temp_directory_path() / "rfsim_ext_manifest_escape";
-    const fs::path manifest_path = writeManifest(
-        root,
-        R"json({
+    const fs::path manifest_path = writeManifest(root,
+                                                 R"json({
             "schema_version": 1,
             "id": "vendor.bad",
             "name": "Bad Tool",
@@ -89,9 +91,8 @@ TEST_CASE("extension manifest rejects entry escaping plugin root", "[extensions]
 
 TEST_CASE("extension manifest rejects unsupported capability", "[extensions][manifest]") {
     const fs::path root = fs::temp_directory_path() / "rfsim_ext_manifest_cap";
-    const fs::path manifest_path = writeManifest(
-        root,
-        R"json({
+    const fs::path manifest_path = writeManifest(root,
+                                                 R"json({
             "schema_version": 1,
             "id": "vendor.viewer",
             "name": "Viewer",
@@ -112,9 +113,9 @@ TEST_CASE("extension manifest rejects unsupported capability", "[extensions][man
 TEST_CASE("extension manager discovers project-local data packs", "[extensions][discovery]") {
     ExtensionManager mgr;
     const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_project";
-    const fs::path manifest_path = writeManifest(
-        project_root / "rf-sim-extensions" / "project-pack",
-        R"json({
+    const fs::path manifest_path =
+        writeManifest(project_root / "rf-sim-extensions" / "project-pack",
+                      R"json({
             "schema_version": 1,
             "id": "project.pack",
             "name": "Project Pack",
@@ -142,9 +143,8 @@ TEST_CASE("extension manager discovers project-local data packs", "[extensions][
 TEST_CASE("extension manager keeps invalid manifests visible", "[extensions][discovery]") {
     ExtensionManager mgr;
     const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_invalid";
-    const fs::path manifest_path = writeManifest(
-        project_root / "rf-sim-extensions" / "bad",
-        R"json({"kind": "external-tool"})json");
+    const fs::path manifest_path = writeManifest(project_root / "rf-sim-extensions" / "bad",
+                                                 R"json({"kind": "external-tool"})json");
 
     mgr.rescan(project_root);
 
@@ -164,18 +164,17 @@ TEST_CASE("extension manager prefers project-local copies over built-in copies",
           "[extensions][discovery]") {
     const fs::path builtin_root = fs::path(PROJECT_SOURCE_DIR) / "extensions" / "rfsim_shadow_case";
     const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_shadow";
-    const fs::path builtin_manifest = writeManifest(
-        builtin_root,
-        R"json({
+    const fs::path builtin_manifest = writeManifest(builtin_root,
+                                                    R"json({
             "schema_version": 1,
             "id": "shared.pack",
             "name": "Built-in Pack",
             "version": "1.0.0",
             "kind": "data-pack"
         })json");
-    const fs::path project_manifest = writeManifest(
-        project_root / "rf-sim-extensions" / "shared-pack",
-        R"json({
+    const fs::path project_manifest =
+        writeManifest(project_root / "rf-sim-extensions" / "shared-pack",
+                      R"json({
             "schema_version": 1,
             "id": "shared.pack",
             "name": "Project Pack",
@@ -190,31 +189,31 @@ TEST_CASE("extension manager prefers project-local copies over built-in copies",
     mgr.rescan(project_root);
 
     const auto &records = mgr.all();
-    const auto record_it = std::find_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
-        return record.manifest && record.manifest->id == "shared.pack";
-    });
+    const auto record_it =
+        std::find_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
+            return record.manifest && record.manifest->id == "shared.pack";
+        });
 
     REQUIRE(record_it != records.end());
     REQUIRE(record_it->manifest_path == project_manifest);
     REQUIRE(record_it->manifest->name == "Project Pack");
     REQUIRE(record_it->status == ExtensionStatusKind::Ok);
     REQUIRE(std::count_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
-        return record.manifest && record.manifest->id == "shared.pack";
-    }) == 1);
+                return record.manifest && record.manifest->id == "shared.pack";
+            }) == 1);
 
     const auto packs = mgr.dataPacks();
     REQUIRE(std::find_if(packs.begin(), packs.end(), [&](const ExtensionManifest *manifest) {
-        return manifest->id == "shared.pack";
-    }) != packs.end());
+                return manifest->id == "shared.pack";
+            }) != packs.end());
 }
 
 TEST_CASE("extension manager excludes malformed compatibility manifests from active queries",
           "[extensions][discovery]") {
     ExtensionManager mgr;
     const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_incompatible";
-    const fs::path manifest_path = writeManifest(
-        project_root / "rf-sim-extensions" / "future-pack",
-        R"json({
+    const fs::path manifest_path = writeManifest(project_root / "rf-sim-extensions" / "future-pack",
+                                                 R"json({
             "schema_version": 1,
             "id": "future.pack",
             "name": "Future Pack",
@@ -226,24 +225,104 @@ TEST_CASE("extension manager excludes malformed compatibility manifests from act
     mgr.rescan(project_root);
 
     const auto &records = mgr.all();
-    const auto record_it = std::find_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
-        return record.manifest_path == manifest_path;
-    });
+    const auto record_it =
+        std::find_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
+            return record.manifest_path == manifest_path;
+        });
 
     REQUIRE(record_it != records.end());
     REQUIRE(record_it->status == ExtensionStatusKind::Incompatible);
     REQUIRE(record_it->manifest.has_value());
     REQUIRE(std::count_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
-        return record.manifest && record.manifest->id == "future.pack";
-    }) == 1);
+                return record.manifest && record.manifest->id == "future.pack";
+            }) == 1);
 
     const auto packs = mgr.dataPacks();
     REQUIRE(std::find_if(packs.begin(), packs.end(), [&](const ExtensionManifest *manifest) {
-        return manifest->id == "future.pack";
-    }) == packs.end());
+                return manifest->id == "future.pack";
+            }) == packs.end());
 
     const auto tools = mgr.externalTools();
     REQUIRE(std::find_if(tools.begin(), tools.end(), [&](const ExtensionManifest *manifest) {
-        return manifest->id == "future.pack";
-    }) == tools.end());
+                return manifest->id == "future.pack";
+            }) == tools.end());
+}
+
+TEST_CASE("external tool runner writes request file and reads result file",
+          "[extensions][runner]") {
+    ExternalToolRunner runner;
+    const fs::path fixture_root =
+        fs::path(PROJECT_SOURCE_DIR) / "tests" / "fixtures" / "extensions";
+    const fs::path work_root = fs::temp_directory_path() / "rfsim_ext_runner_ok";
+    ScopedRemove cleanup{work_root};
+
+    ExtensionManifest manifest;
+    manifest.kind = ExtensionKind::ExternalTool;
+    manifest.id = "vendor.echo-generator";
+    manifest.name = "Echo Generator";
+    manifest.version = "1.0.0";
+    manifest.root_dir = fixture_root;
+    manifest.entry_path = fixture_root / "echo_tool.py";
+
+    const fs::path selected_path = work_root / "inputs" / "selection.s2p";
+    fs::create_directories(selected_path.parent_path());
+    std::ofstream(selected_path) << "touchstone input";
+
+    const ExternalToolRequest request{
+        "1",           "Generate",         work_root,
+        selected_path, work_root / "work", work_root / "work" / "result.json"};
+
+    const auto result = runner.run(manifest, request);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.exit_code == 0);
+    REQUIRE(result.message == "tool ok");
+    REQUIRE(result.work_dir == request.work_dir);
+    REQUIRE(fs::exists(request.work_dir / "request.json"));
+    REQUIRE(fs::exists(request.result_path));
+
+    const nlohmann::json request_json =
+        nlohmann::json::parse(std::ifstream(request.work_dir / "request.json"), nullptr, false);
+    REQUIRE_FALSE(request_json.is_discarded());
+    REQUIRE(request_json["action_label"] == "Generate");
+    REQUIRE(request_json["project_root"] == work_root.generic_string());
+    REQUIRE(request_json["selected_path"] == selected_path.generic_string());
+    REQUIRE(request_json["result_path"] == request.result_path.generic_string());
+
+    const nlohmann::json result_json =
+        nlohmann::json::parse(std::ifstream(request.result_path), nullptr, false);
+    REQUIRE_FALSE(result_json.is_discarded());
+    REQUIRE(result_json["result_type"] == "report_created");
+    REQUIRE(result_json["request"]["action_label"] == "Generate");
+}
+
+TEST_CASE("external tool runner reports missing result as failure", "[extensions][runner]") {
+    ExternalToolRunner runner;
+    const fs::path fixture_root =
+        fs::path(PROJECT_SOURCE_DIR) / "tests" / "fixtures" / "extensions";
+    const fs::path work_root = fs::temp_directory_path() / "rfsim_ext_runner_fail";
+    ScopedRemove cleanup{work_root};
+
+    ExtensionManifest manifest;
+    manifest.kind = ExtensionKind::ExternalTool;
+    manifest.id = "vendor.noop";
+    manifest.name = "Noop Tool";
+    manifest.version = "1.0.0";
+    manifest.root_dir = fixture_root;
+    manifest.entry_path = fixture_root / "noop_tool.py";
+
+    const ExternalToolRequest request{"1",
+                                      "Check",
+                                      work_root,
+                                      work_root / "input.txt",
+                                      work_root / "work",
+                                      work_root / "work" / "result.json"};
+
+    const auto result = runner.run(manifest, request);
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.exit_code == 0);
+    REQUIRE(result.message == "result file missing");
+    REQUIRE(fs::exists(request.work_dir / "request.json"));
+    REQUIRE_FALSE(fs::exists(request.result_path));
 }

--- a/tests/test_extensions.cpp
+++ b/tests/test_extensions.cpp
@@ -10,11 +10,28 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "imgui.h"
+#include "imnodes.h"
+#include "implot.h"
 #include <filesystem>
 #include <fstream>
 #include <string>
 #include <system_error>
 #include <vector>
+
+struct ImGuiFixture {
+    ImGuiFixture() {
+        ImGui::CreateContext();
+        ImPlot::CreateContext();
+        ImNodes::CreateContext();
+    }
+
+    ~ImGuiFixture() {
+        ImNodes::DestroyContext();
+        ImPlot::DestroyContext();
+        ImGui::DestroyContext();
+    }
+};
 
 namespace fs = std::filesystem;
 
@@ -325,4 +342,79 @@ TEST_CASE("external tool runner reports missing result as failure", "[extensions
     REQUIRE(result.message == "result file missing");
     REQUIRE(fs::exists(request.work_dir / "request.json"));
     REQUIRE_FALSE(fs::exists(request.result_path));
+}
+
+TEST_CASE_METHOD(ImGuiFixture, "app refreshExtensions discovers project-local data packs",
+                 "[extensions][app]") {
+    const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_app";
+    ScopedRemove cleanup{project_root};
+
+    const fs::path manifest_path =
+        writeManifest(project_root / "rf-sim-extensions" / "project-pack",
+                      R"json({
+            "schema_version": 1,
+            "id": "project.pack",
+            "name": "Project Pack",
+            "version": "1.0.0",
+            "kind": "data-pack"
+        })json");
+
+    RfSimulatorApp app;
+    app.m_current_project_path = (project_root / "demo.rfsim").string();
+    app.refreshExtensions();
+
+    const auto &records = app.testExtensionManager().all();
+    REQUIRE(std::find_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
+                return record.manifest_path == manifest_path;
+            }) != records.end());
+
+    const auto packs = app.testExtensionManager().dataPacks();
+    REQUIRE(std::find_if(packs.begin(), packs.end(), [&](const ExtensionManifest *manifest) {
+                return manifest->id == "project.pack";
+            }) != packs.end());
+}
+
+TEST_CASE_METHOD(ImGuiFixture, "app runExternalTool records success message", "[extensions][app]") {
+    const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_app_tool";
+    ScopedRemove cleanup{project_root};
+
+    const fs::path tool_dir = project_root / "rf-sim-extensions" / "echo-tool";
+    const fs::path script_path = tool_dir / "bin" / "echo_tool.py";
+    fs::create_directories(script_path.parent_path());
+    {
+        std::ofstream out(script_path);
+        out << "#!/usr/bin/env python3\n"
+            << "import json\n"
+            << "import pathlib\n"
+            << "import sys\n\n"
+            << "request = pathlib.Path(sys.argv[sys.argv.index(\"--request\") + 1])\n"
+            << "result = pathlib.Path(sys.argv[sys.argv.index(\"--result\") + 1])\n"
+            << "request_json = json.loads(request.read_text(encoding=\"utf-8\"))\n"
+            << "result.write_text(json.dumps({\"result_type\": \"report_created\", "
+               "\"message\": \"tool ok\", \"request\": request_json}, indent=2) + \"\\n\", "
+               "encoding=\"utf-8\")\n";
+    }
+
+    writeManifest(tool_dir,
+                  R"json({
+            "schema_version": 1,
+            "id": "project.echo",
+            "name": "Project Echo",
+            "version": "1.0.0",
+            "kind": "external-tool",
+            "capabilities": ["generator"],
+            "entry": "bin/echo_tool.py",
+            "menus": [{"location": "tools", "label": "Echo"}]
+        })json");
+
+    RfSimulatorApp app;
+    app.m_current_project_path = (project_root / "demo.rfsim").string();
+    app.refreshExtensions();
+
+    const auto &tools = app.testExtensionManager().externalTools();
+    REQUIRE_FALSE(tools.empty());
+
+    app.runExternalTool(*tools.front());
+
+    REQUIRE(app.testExtensionResultMessage().find("Extension run succeeded") != std::string::npos);
 }

--- a/tests/test_extensions.cpp
+++ b/tests/test_extensions.cpp
@@ -9,6 +9,8 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <system_error>
+
 
 namespace fs = std::filesystem;
 
@@ -21,6 +23,16 @@ fs::path writeManifest(const fs::path &dir, const std::string &body) {
     out << body;
     return path;
 }
+
+struct ScopedRemove {
+    fs::path path;
+
+    ~ScopedRemove() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
 
 } // namespace
 
@@ -146,4 +158,92 @@ TEST_CASE("extension manager keeps invalid manifests visible", "[extensions][dis
     REQUIRE(record_it->status == ExtensionStatusKind::Invalid);
     REQUIRE_FALSE(record_it->manifest.has_value());
     REQUIRE_FALSE(record_it->issues.empty());
+}
+
+TEST_CASE("extension manager prefers project-local copies over built-in copies",
+          "[extensions][discovery]") {
+    const fs::path builtin_root = fs::path(PROJECT_SOURCE_DIR) / "extensions" / "rfsim_shadow_case";
+    const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_shadow";
+    const fs::path builtin_manifest = writeManifest(
+        builtin_root,
+        R"json({
+            "schema_version": 1,
+            "id": "shared.pack",
+            "name": "Built-in Pack",
+            "version": "1.0.0",
+            "kind": "data-pack"
+        })json");
+    const fs::path project_manifest = writeManifest(
+        project_root / "rf-sim-extensions" / "shared-pack",
+        R"json({
+            "schema_version": 1,
+            "id": "shared.pack",
+            "name": "Project Pack",
+            "version": "2.0.0",
+            "kind": "data-pack"
+        })json");
+    ScopedRemove cleanup{builtin_root};
+
+    REQUIRE(fs::exists(builtin_manifest));
+
+    ExtensionManager mgr;
+    mgr.rescan(project_root);
+
+    const auto &records = mgr.all();
+    const auto record_it = std::find_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
+        return record.manifest && record.manifest->id == "shared.pack";
+    });
+
+    REQUIRE(record_it != records.end());
+    REQUIRE(record_it->manifest_path == project_manifest);
+    REQUIRE(record_it->manifest->name == "Project Pack");
+    REQUIRE(record_it->status == ExtensionStatusKind::Ok);
+    REQUIRE(std::count_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
+        return record.manifest && record.manifest->id == "shared.pack";
+    }) == 1);
+
+    const auto packs = mgr.dataPacks();
+    REQUIRE(std::find_if(packs.begin(), packs.end(), [&](const ExtensionManifest *manifest) {
+        return manifest->id == "shared.pack";
+    }) != packs.end());
+}
+
+TEST_CASE("extension manager excludes incompatible manifests from active queries",
+          "[extensions][discovery]") {
+    ExtensionManager mgr;
+    const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_incompatible";
+    const fs::path manifest_path = writeManifest(
+        project_root / "rf-sim-extensions" / "future-pack",
+        R"json({
+            "schema_version": 1,
+            "id": "future.pack",
+            "name": "Future Pack",
+            "version": "1.0.0",
+            "kind": "data-pack",
+            "compat": {"min_app_version": "99.0.0"}
+        })json");
+
+    mgr.rescan(project_root);
+
+    const auto &records = mgr.all();
+    const auto record_it = std::find_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
+        return record.manifest_path == manifest_path;
+    });
+
+    REQUIRE(record_it != records.end());
+    REQUIRE(record_it->status == ExtensionStatusKind::Incompatible);
+    REQUIRE(record_it->manifest.has_value());
+    REQUIRE(std::count_if(records.begin(), records.end(), [&](const ExtensionRecord &record) {
+        return record.manifest && record.manifest->id == "future.pack";
+    }) == 1);
+
+    const auto packs = mgr.dataPacks();
+    REQUIRE(std::find_if(packs.begin(), packs.end(), [&](const ExtensionManifest *manifest) {
+        return manifest->id == "future.pack";
+    }) == packs.end());
+
+    const auto tools = mgr.externalTools();
+    REQUIRE(std::find_if(tools.begin(), tools.end(), [&](const ExtensionManifest *manifest) {
+        return manifest->id == "future.pack";
+    }) == tools.end());
 }

--- a/tests/test_extensions.cpp
+++ b/tests/test_extensions.cpp
@@ -1,0 +1,95 @@
+#include "extension_manifest.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+fs::path writeManifest(const fs::path &dir, const std::string &body) {
+    fs::create_directories(dir);
+    const fs::path path = dir / "plugin.json";
+    std::ofstream out(path);
+    out << body;
+    return path;
+}
+
+} // namespace
+
+TEST_CASE("extension manifest parses valid external-tool generator", "[extensions][manifest]") {
+    const fs::path root = fs::temp_directory_path() / "rfsim_ext_manifest_ok";
+    const fs::path manifest_path = writeManifest(
+        root,
+        R"json({
+            "schema_version": 1,
+            "id": "vendor.amp-f-generator",
+            "name": "AMP_F Generator",
+            "version": "1.0.0",
+            "kind": "external-tool",
+            "capabilities": ["generator"],
+            "entry": "bin/adapter.py",
+            "menus": [{"location": "tools", "label": "Generate amplifier data..."}],
+            "compat": {"min_app_version": "0.14.0"}
+        })json");
+
+    std::vector<ExtensionValidationIssue> issues;
+    const auto manifest = parseExtensionManifest(manifest_path, issues);
+
+    REQUIRE(manifest.has_value());
+    REQUIRE(issues.empty());
+    REQUIRE(manifest->kind == ExtensionKind::ExternalTool);
+    REQUIRE(manifest->capabilities == std::vector<ExtensionCapability>{ExtensionCapability::Generator});
+    REQUIRE(manifest->entry_path == fs::weakly_canonical(root / "bin/adapter.py"));
+    REQUIRE(manifest->menus.size() == 1);
+    REQUIRE(manifest->menus.front().location == "tools");
+    REQUIRE(manifest->menus.front().label == "Generate amplifier data...");
+}
+
+TEST_CASE("extension manifest rejects entry escaping plugin root", "[extensions][manifest]") {
+    const fs::path root = fs::temp_directory_path() / "rfsim_ext_manifest_escape";
+    const fs::path manifest_path = writeManifest(
+        root,
+        R"json({
+            "schema_version": 1,
+            "id": "vendor.bad",
+            "name": "Bad Tool",
+            "version": "1.0.0",
+            "kind": "external-tool",
+            "capabilities": ["generator"],
+            "entry": "../python.exe"
+        })json");
+
+    std::vector<ExtensionValidationIssue> issues;
+    const auto manifest = parseExtensionManifest(manifest_path, issues);
+
+    REQUIRE_FALSE(manifest.has_value());
+    REQUIRE_FALSE(issues.empty());
+    REQUIRE(issues.front().field == "entry");
+}
+
+TEST_CASE("extension manifest rejects unsupported capability", "[extensions][manifest]") {
+    const fs::path root = fs::temp_directory_path() / "rfsim_ext_manifest_cap";
+    const fs::path manifest_path = writeManifest(
+        root,
+        R"json({
+            "schema_version": 1,
+            "id": "vendor.viewer",
+            "name": "Viewer",
+            "version": "1.0.0",
+            "kind": "external-tool",
+            "capabilities": ["viewer"],
+            "entry": "bin/viewer.exe"
+        })json");
+
+    std::vector<ExtensionValidationIssue> issues;
+    const auto manifest = parseExtensionManifest(manifest_path, issues);
+
+    REQUIRE_FALSE(manifest.has_value());
+    REQUIRE_FALSE(issues.empty());
+    REQUIRE(issues.front().field == "capabilities[0]");
+}

--- a/tests/test_extensions.cpp
+++ b/tests/test_extensions.cpp
@@ -208,7 +208,7 @@ TEST_CASE("extension manager prefers project-local copies over built-in copies",
     }) != packs.end());
 }
 
-TEST_CASE("extension manager excludes incompatible manifests from active queries",
+TEST_CASE("extension manager excludes malformed compatibility manifests from active queries",
           "[extensions][discovery]") {
     ExtensionManager mgr;
     const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_incompatible";
@@ -220,7 +220,7 @@ TEST_CASE("extension manager excludes incompatible manifests from active queries
             "name": "Future Pack",
             "version": "1.0.0",
             "kind": "data-pack",
-            "compat": {"min_app_version": "99.0.0"}
+            "compat": {"min_app_version": "99-beta"}
         })json");
 
     mgr.rescan(project_root);

--- a/tests/test_extensions.cpp
+++ b/tests/test_extensions.cpp
@@ -127,6 +127,30 @@ TEST_CASE("extension manifest rejects unsupported capability", "[extensions][man
     REQUIRE(issues.front().field == "capabilities[0]");
 }
 
+TEST_CASE("extension manifest preserves non-tools menu locations", "[extensions][manifest]") {
+    const fs::path root = fs::temp_directory_path() / "rfsim_ext_manifest_menu";
+    const fs::path manifest_path = writeManifest(root,
+                                                 R"json({
+            "schema_version": 1,
+            "id": "vendor.bad-menu",
+            "name": "Bad Menu",
+            "version": "1.0.0",
+            "kind": "external-tool",
+            "capabilities": ["generator"],
+            "entry": "bin/tool.py",
+            "menus": [{"location": "toolbar", "label": "Run"}]
+        })json");
+
+    std::vector<ExtensionValidationIssue> issues;
+    const auto manifest = parseExtensionManifest(manifest_path, issues);
+
+    REQUIRE(manifest.has_value());
+    REQUIRE(issues.empty());
+    REQUIRE(manifest->menus.size() == 1);
+    REQUIRE(manifest->menus.front().location == "toolbar");
+    REQUIRE(manifest->menus.front().label == "Run");
+}
+
 TEST_CASE("extension manager discovers project-local data packs", "[extensions][discovery]") {
     ExtensionManager mgr;
     const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_project";
@@ -417,4 +441,164 @@ TEST_CASE_METHOD(ImGuiFixture, "app runExternalTool records success message", "[
     app.runExternalTool(*tools.front());
 
     REQUIRE(app.testExtensionResultMessage().find("Extension run succeeded") != std::string::npos);
+}
+
+TEST_CASE_METHOD(ImGuiFixture, "app runExternalTool passes selected menu label to the tool",
+                 "[extensions][app]") {
+    const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_app_tool_action";
+    ScopedRemove cleanup{project_root};
+
+    const fs::path tool_dir = project_root / "rf-sim-extensions" / "multi-action-tool";
+    const fs::path script_path = tool_dir / "bin" / "action_tool.py";
+    const fs::path action_path = tool_dir / "last_action.txt";
+    fs::create_directories(script_path.parent_path());
+    {
+        std::ofstream out(script_path);
+        out << "#!/usr/bin/env python3\n"
+            << "import json\n"
+            << "import pathlib\n"
+            << "import sys\n\n"
+            << "request = pathlib.Path(sys.argv[sys.argv.index(\"--request\") + 1])\n"
+            << "result = pathlib.Path(sys.argv[sys.argv.index(\"--result\") + 1])\n"
+            << "request_json = json.loads(request.read_text(encoding=\"utf-8\"))\n"
+            << "pathlib.Path(r\"" << action_path.generic_string()
+            << "\").write_text("
+               "request_json[\"action_label\"], encoding=\"utf-8\")\n"
+            << "result.write_text(json.dumps({\"result_type\": \"report_created\", "
+               "\"message\": \"tool ok\"}) + \"\\n\", encoding=\"utf-8\")\n";
+    }
+
+    writeManifest(tool_dir,
+                  R"json({
+            "schema_version": 1,
+            "id": "project.multi-action",
+            "name": "Project Multi Action",
+            "version": "1.0.0",
+            "kind": "external-tool",
+            "capabilities": ["generator"],
+            "entry": "bin/action_tool.py",
+            "menus": [
+                {"location": "tools", "label": "Generate"},
+                {"location": "tools", "label": "Import"}
+            ]
+        })json");
+
+    RfSimulatorApp app;
+    app.m_current_project_path = (project_root / "demo.rfsim").string();
+    app.refreshExtensions();
+
+    const auto &tools = app.testExtensionManager().externalTools();
+    REQUIRE(std::size(tools) == 1);
+
+    app.runExternalTool(*tools.front(), "Import");
+
+    REQUIRE(fs::exists(action_path));
+    REQUIRE(std::ifstream(action_path).good());
+    std::string action_label;
+    std::ifstream action_in(action_path);
+    std::getline(action_in, action_label);
+    REQUIRE(action_label == "Import");
+}
+
+TEST_CASE_METHOD(ImGuiFixture, "app externalToolActions preserves declared menu actions",
+                 "[extensions][app]") {
+    const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_app_tool_actions";
+    ScopedRemove cleanup{project_root};
+
+    const fs::path tool_dir = project_root / "rf-sim-extensions" / "multi-action-tool";
+    const fs::path script_path = tool_dir / "bin" / "action_tool.py";
+    fs::create_directories(script_path.parent_path());
+    {
+        std::ofstream out(script_path);
+        out << "#!/usr/bin/env python3\n"
+            << "import json\n"
+            << "import pathlib\n"
+            << "import sys\n\n"
+            << "result = pathlib.Path(sys.argv[sys.argv.index(\"--result\") + 1])\n"
+            << "result.write_text(json.dumps({\"result_type\": \"report_created\", "
+               "\"message\": \"tool ok\"}) + \"\\n\", encoding=\"utf-8\")\n";
+    }
+
+    writeManifest(tool_dir,
+                  R"json({
+            "schema_version": 1,
+            "id": "project.multi-action",
+            "name": "Project Multi Action",
+            "version": "1.0.0",
+            "kind": "external-tool",
+            "capabilities": ["generator"],
+            "entry": "bin/action_tool.py",
+            "menus": [
+                {"location": "tools", "label": "Generate"},
+                {"location": "toolbar", "label": "Import"}
+            ]
+        })json");
+
+    RfSimulatorApp app;
+    app.m_current_project_path = (project_root / "demo.rfsim").string();
+    app.refreshExtensions();
+
+    const auto &tools = app.testExtensionManager().externalTools();
+    REQUIRE(std::size(tools) == 1);
+
+    const auto actions = app.externalToolActions(*tools.front());
+    REQUIRE(actions.size() == 2);
+    REQUIRE(actions[0].location == "tools");
+    REQUIRE(actions[0].label == "Generate");
+    REQUIRE(actions[1].location == "toolbar");
+    REQUIRE(actions[1].label == "Import");
+}
+
+TEST_CASE_METHOD(ImGuiFixture, "app runExternalTool does not reuse stale result files",
+                 "[extensions][app]") {
+    const fs::path project_root = fs::temp_directory_path() / "rfsim_ext_app_tool_stale";
+    ScopedRemove cleanup{project_root};
+
+    const fs::path tool_dir = project_root / "rf-sim-extensions" / "flaky-tool";
+    const fs::path script_path = tool_dir / "bin" / "flaky_tool.py";
+    fs::create_directories(script_path.parent_path());
+    {
+        std::ofstream out(script_path);
+        out << "#!/usr/bin/env python3\n"
+            << "import json\n"
+            << "import pathlib\n"
+            << "import sys\n\n"
+            << "result = pathlib.Path(sys.argv[sys.argv.index(\"--result\") + 1])\n"
+            << "result.write_text(json.dumps({\"result_type\": \"report_created\", "
+               "\"message\": \"first run ok\"}) + \"\\n\", encoding=\"utf-8\")\n";
+    }
+
+    writeManifest(tool_dir,
+                  R"json({
+            "schema_version": 1,
+            "id": "project.flaky-tool",
+            "name": "Project Flaky Tool",
+            "version": "1.0.0",
+            "kind": "external-tool",
+            "capabilities": ["generator"],
+            "entry": "bin/flaky_tool.py",
+            "menus": [{"location": "tools", "label": "Run"}]
+        })json");
+
+    RfSimulatorApp app;
+    app.m_current_project_path = (project_root / "demo.rfsim").string();
+    app.refreshExtensions();
+
+    const auto &tools = app.testExtensionManager().externalTools();
+    REQUIRE(std::size(tools) == 1);
+
+    app.runExternalTool(*tools.front(), "Run");
+    REQUIRE(app.testExtensionResultMessage().find("Extension run succeeded") != std::string::npos);
+
+    {
+        std::ofstream out(script_path);
+        out << "#!/usr/bin/env python3\n"
+            << "import sys\n"
+            << "sys.exit(0)\n";
+    }
+
+    app.runExternalTool(*tools.front(), "Run");
+
+    REQUIRE(app.testExtensionResultMessage().find("Extension run failed") != std::string::npos);
+    REQUIRE(app.testExtensionResultMessage().find("result file missing") != std::string::npos);
 }


### PR DESCRIPTION
## Summary

Add the first plugin extension system slice for external tools and data packs: manifest parsing/discovery, structured external-tool execution, Tools/Extensions-panel integration, and regression coverage for action routing/result handling.

## Related issue

Closes #2

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Build / CI

## Test plan

- [ ] `cmake -B build -G Ninja && cmake --build build`
- [ ] `ctest --test-dir build --output-on-failure`
- [x] `cmake --build build --target test_extensions`
- [x] `ctest --test-dir build -R test_extensions --output-on-failure`
- [x] `ctest --test-dir build --output-on-failure` still reproduces the existing baseline failure on test `#147`, which also fails on current `master`
- [ ] Manual verification steps (if applicable):

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran `clang-format -i` on changed files
- [x] I added or updated tests where appropriate
- [ ] Existing tests still pass
