### PR TITLE
fix: capture PROJECT_VERSION before FetchContent clobbers it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ cmake_minimum_required (VERSION 3.20)
 
 project (RfSimulator VERSION 0.14.0)
 
+# FetchContent'd dependencies below call their own project() commands, which
+# resets PROJECT_VERSION (and _MAJOR/_MINOR/_PATCH) for the remainder of this
+# configure run. Capture it now so downstream targets (e.g. app's APP_VERSION
+# compile definition) get the real project version instead of an empty string.
+set(RFSIM_APP_VERSION "${PROJECT_VERSION}")
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,12 @@ project (RfSimulator VERSION 0.14.0)
 # FetchContent'd dependencies below call their own project() commands, which
 # resets PROJECT_VERSION (and _MAJOR/_MINOR/_PATCH) for the remainder of this
 # configure run. Capture it now so downstream targets (e.g. app's APP_VERSION
-# compile definition) get the real project version instead of an empty string.
+# compile definition, CPack packaging metadata) get the real project version
+# instead of an empty string.
 set(RFSIM_APP_VERSION "${PROJECT_VERSION}")
+set(RFSIM_APP_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
+set(RFSIM_APP_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
+set(RFSIM_APP_VERSION_PATCH "${PROJECT_VERSION_PATCH}")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -232,10 +236,10 @@ install(DIRECTORY openwiki/ DESTINATION share/doc/rf-simulator/openwiki
 set(CPACK_PACKAGE_NAME "rf-simulator")
 set(CPACK_PACKAGE_VENDOR "RF Simulator Project")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Tiny RF Simulator")
-set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
-set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+set(CPACK_PACKAGE_VERSION ${RFSIM_APP_VERSION})
+set(CPACK_PACKAGE_VERSION_MAJOR ${RFSIM_APP_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${RFSIM_APP_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${RFSIM_APP_VERSION_PATCH})
 set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
 
 # Platform-specific generators

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -66,7 +66,7 @@ execute_process(COMMAND git log -1 --format=%h
 
 target_compile_definitions(app PRIVATE
     PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
-    APP_VERSION="${PROJECT_VERSION}"
+    APP_VERSION="${RFSIM_APP_VERSION}"
     APP_GIT_HASH="${GIT_COMMIT_HASH}"
 )
 


### PR DESCRIPTION
## Problem

FetchContent'd dependencies (imgui, implot, etc.) each call their own nested `project()` command, which resets CMake's `PROJECT_VERSION` (and `_MAJOR`/`_MINOR`/`_PATCH`) for the remainder of the configure run. `app/CMakeLists.txt` reads `PROJECT_VERSION` *after* those FetchContent calls, so `APP_VERSION` compiled as an **empty string**.

This silently broke extension manifest compatibility checks: `ExtensionManager::statusForManifest()` compares a manifest's declared `compat.min_app_version` against `APP_VERSION` via `compareVersions()`, which fails to parse an empty string and returns `nullopt` — so **any manifest with a non-empty `compat.min_app_version` was marked `Incompatible` and excluded from `dataPacks()`/`externalTools()`**, regardless of the actual running app version.

The same clobbered value also fed `CPACK_PACKAGE_VERSION`/`_MAJOR`/`_MINOR`/`_PATCH`, so release packaging (CPack, triggered by `v*` tags per CONTRIBUTING.md) was building with an empty version string.

## Fix

Capture `PROJECT_VERSION` (and its components) into `RFSIM_APP_VERSION*` immediately after the top-level `project()` call, before any `FetchContent` dependency can reset it, and read those captured variables everywhere `APP_VERSION`/`CPACK_PACKAGE_VERSION*` were previously read directly from `PROJECT_VERSION`.

## Verification

- `cmake -B build && cmake --build build --target test_extensions` — clean build
- `build/bin/test_extensions.exe "[extensions]"` — all tests pass, no regressions (registration count also improved: 15/15 test cases now register vs. 11/15 previously observed under some launch paths — see note below)
- Confirmed via `build/CPackConfig.cmake`: `CPACK_PACKAGE_VERSION` now resolves to `"0.14.0"` instead of empty

## Note

Discovered while building a new extension (separate branch/PR) whose manifest declares `compat.min_app_version` — it was unexpectedly showing as `Incompatible` until this fix. This fix stands alone and has no other dependency.