### PR TITLE
fix: add checkboxes to reopen closed PFB IQ/grid windows

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -25,6 +25,7 @@ Application orchestrator layer containing `RfSimulatorApp`, `ComponentRegistry`,
 - `draw_ui()` and `drawExtensionsPanel()` both dispatch through `externalToolActions()`; the Tools menu renders only actions whose `location == "tools"`, while the Extensions panel shows every declared action (or a single fallback Run button)
 - App-level integration tests may use `testExtensionManager()` and `testExtensionResultMessage()` with an ImGui/ImPlot/ImNodes fixture
 - `load_window_states()` runs on construction to restore persisted window visibility toggles
+- Per-PFB IQ Plot / Channelizer Grid window visibility (`m_show_iq_pfbs`/`m_show_pfb_grids`, indexed in lockstep with `m_pfb_ptrs`) has no View-menu entry since instances are dynamic; closed windows are reopened via "Show IQ Plot"/"Show Channelizer Grid" checkboxes in the PFB properties panel, wired each frame through `InspectorPanel::setPFBWindowVisibility()` (stores the stable vector pointers, not element pointers, since the vectors are rebuilt on add/remove)
 - Destructor saves window state via `SessionState`
 
 ## Work Guidance

--- a/app/include/inspector_panel.h
+++ b/app/include/inspector_panel.h
@@ -39,6 +39,13 @@ class InspectorPanel {
         if (m_selected_pfb_index >= static_cast<int>(m_pfb_ptrs.size()))
             m_selected_pfb_index = std::max(0, static_cast<int>(m_pfb_ptrs.size()) - 1);
     }
+    // Vectors are owned by the caller (RfSimulatorApp) and stay stable across frames;
+    // only their contents are rebuilt on add/remove, so storing the vector pointers
+    // here is safe as long as we index into them fresh on every draw() call.
+    void setPFBWindowVisibility(std::vector<bool> *iq_visible, std::vector<bool> *grid_visible) {
+        m_pfb_iq_visible = iq_visible;
+        m_pfb_grid_visible = grid_visible;
+    }
 
     std::function<void(int graph_node_id)> onRemoveNode;
     std::function<void()> onParamChange;
@@ -51,6 +58,8 @@ class InspectorPanel {
     std::vector<PFBChannelizerEngine *> m_pfb_ptrs;
     int m_selected_pfb_index = 0;
     ViewToggles m_viewToggles;
+    std::vector<bool> *m_pfb_iq_visible = nullptr;
+    std::vector<bool> *m_pfb_grid_visible = nullptr;
 
     enum class ComponentType {
         None,

--- a/app/src/app.cpp
+++ b/app/src/app.cpp
@@ -957,6 +957,7 @@ void RfSimulatorApp::update_dsp() {
     std::vector<PFBChannelizerEngine *> pfb_vec(pfb_ptrs.begin(), pfb_ptrs.end());
     m_spectrum_widget->setPFBs(pfb_vec);
     m_inspector_panel->setPFBs(pfb_vec);
+    m_inspector_panel->setPFBWindowVisibility(&m_show_iq_pfbs, &m_show_pfb_grids);
 }
 
 void RfSimulatorApp::draw_ui() {

--- a/app/src/inspector_panel.cpp
+++ b/app/src/inspector_panel.cpp
@@ -742,6 +742,19 @@ void InspectorPanel::drawPFBProperties(PFBChannelizerEngine &engine) {
         ImGui::Text("Noise: %.3e W", active.noise_W);
     }
 
+    if (m_pfb_iq_visible && m_selected_pfb_index >= 0 &&
+        m_selected_pfb_index < static_cast<int>(m_pfb_iq_visible->size())) {
+        bool show = (*m_pfb_iq_visible)[m_selected_pfb_index];
+        if (ImGui::Checkbox("Show IQ Plot", &show))
+            (*m_pfb_iq_visible)[m_selected_pfb_index] = show;
+    }
+    if (m_pfb_grid_visible && m_selected_pfb_index >= 0 &&
+        m_selected_pfb_index < static_cast<int>(m_pfb_grid_visible->size())) {
+        bool show = (*m_pfb_grid_visible)[m_selected_pfb_index];
+        if (ImGui::Checkbox("Show Channelizer Grid", &show))
+            (*m_pfb_grid_visible)[m_selected_pfb_index] = show;
+    }
+
     if (ImGui::Button("Delete") && onRemoveNode)
         onRemoveNode(engine.graphNodeId());
 }


### PR DESCRIPTION
Fixes #32

Per-PFB IQ Plot / Channelizer Grid window visibility had no way to be toggled back on once closed (unlike Log/Spectrum/Properties/Node Editor, which have View menu checkboxes). The only recovery path was the incidental add/remove-any-component rebuild.

Adds "Show IQ Plot" / "Show Channelizer Grid" checkboxes to the PFB properties panel, wired via `InspectorPanel::setPFBWindowVisibility()`.

Verified: full build + `tests.exe` (65522 assertions / 217 cases) pass.