### PR TITLE
chore: bump version to 0.15.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.20)
 
-project (RfSimulator VERSION 0.14.1)
+project (RfSimulator VERSION 0.15.0)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Summary

Bump the project version from `0.14.1` to `0.15.0` so the tag-based release workflow accepts `v0.15.0`.

## Related issue

N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Build / CI

## Test plan

- [x] `cmake --build build`
- [x] `ctest --test-dir build --output-on-failure -E "Benchmark|test_ui|ADC DDC output grid spans"`
- [x] Manual verification steps (if applicable):
  - Verified `CMakeLists.txt` now contains `project (RfSimulator VERSION 0.15.0)`
  - Verified the release workflow checks the tag against `CMakeLists.txt`, so `v0.15.0` will match

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [ ] I ran `clang-format -i` on changed files (N/A: no C++ file changes)
- [ ] I added or updated tests where appropriate (N/A: version-only change)
- [x] Existing tests still pass
