### PR TITLE
fix: null dangling downstream input pointer on node removal

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -26,6 +26,7 @@ Application orchestrator layer containing `RfSimulatorApp`, `ComponentRegistry`,
 - App-level integration tests may use `testExtensionManager()` and `testExtensionResultMessage()` with an ImGui/ImPlot/ImNodes fixture
 - `load_window_states()` runs on construction to restore persisted window visibility toggles
 - Per-PFB IQ Plot / Channelizer Grid window visibility (`m_show_iq_pfbs`/`m_show_pfb_grids`, indexed in lockstep with `m_pfb_ptrs`) has no View-menu entry since instances are dynamic; closed windows are reopened via "Show IQ Plot"/"Show Channelizer Grid" checkboxes in the PFB properties panel, wired each frame through `InspectorPanel::setPFBWindowVisibility()` (stores the stable vector pointers, not element pointers, since the vectors are rebuilt on add/remove)
+- `update_dsp()`'s signal-routing pass is factored into `rewireInputs()` (sets every component's `node().inputs[k]` from current graph links, nulling severed ones); `onRemoveNode` calls it synchronously right after `ComponentRegistry::remove()` so no surviving component is left holding a dangling `Spectrum*` into the just-destroyed engine's `SignalNode` while the rest of that frame's `draw_ui()` still runs — widgets that dereference `node().inputs[]` directly during draw (e.g. `PFBChannelizerWidget`) would otherwise use-after-free (issue #37)
 - Destructor saves window state via `SessionState`
 
 ## Work Guidance

--- a/app/include/app.h
+++ b/app/include/app.h
@@ -91,6 +91,7 @@ class RfSimulatorApp {
 
   private:
     void load_window_states();
+    void rewireInputs();
     void duplicateComponent(int graph_node_id);
     void openNewComponentForm(const std::string &type);
     void openEditComponentForm(const ComponentDefinition &def);

--- a/app/src/app.cpp
+++ b/app/src/app.cpp
@@ -113,6 +113,15 @@ RfSimulatorApp::RfSimulatorApp() : m_components(m_graph_engine, m_view_manager) 
     m_graph_widget->onRemoveNode = [this](int id) {
         markDirty();
         m_components.remove(id);
+        // Immediately re-wire remaining components' inputs against the current graph
+        // topology. Node removal only strips graph links/pin bookkeeping; it does not
+        // touch SignalNode::inputs pointers held by surviving components, and the next
+        // scheduled rewire (update_dsp(), start of next frame) hasn't run yet. Any
+        // component downstream of the removed node still holds a raw Spectrum* into the
+        // just-destroyed engine's SignalNode. Widgets that dereference node().inputs[]
+        // directly during this same draw_ui() call (e.g. PFBChannelizerWidget::draw() /
+        // rebuildCache(), InspectorPanel) would otherwise use-after-free. See issue #37.
+        rewireInputs();
         auto pfb_vec = m_components.byType<PFBChannelizerEngine>();
         m_iq_widgets.clear();
         m_show_iq_pfbs.clear();
@@ -906,9 +915,7 @@ void RfSimulatorApp::drawComponentFormModal() {
     }
 }
 
-void RfSimulatorApp::update_dsp() {
-    std::unordered_map<int, std::function<void()>> updates;
-
+void RfSimulatorApp::rewireInputs() {
     for (auto *comp : m_components.all()) {
         int N = comp->numInputPins();
         for (int k = 0; k < N; ++k) {
@@ -920,6 +927,14 @@ void RfSimulatorApp::update_dsp() {
                 comp->node().inputs[k] = nullptr;
             }
         }
+    }
+}
+
+void RfSimulatorApp::update_dsp() {
+    rewireInputs();
+
+    std::unordered_map<int, std::function<void()>> updates;
+    for (auto *comp : m_components.all()) {
         updates[comp->graphNodeId()] = [comp]() { comp->update(0.0); };
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,3 +96,11 @@ target_link_libraries(test_extensions PRIVATE
 )
 target_compile_definitions(test_extensions PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 add_test(NAME test_extensions COMMAND test_extensions WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_executable(test_issue37_pfb_input_removal test_issue37_pfb_input_removal.cpp)
+target_link_libraries(test_issue37_pfb_input_removal PRIVATE
+    simulator::app
+    Catch2::Catch2WithMain
+)
+target_compile_definitions(test_issue37_pfb_input_removal PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+add_test(NAME test_issue37_pfb_input_removal COMMAND test_issue37_pfb_input_removal WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/tests/test_issue37_pfb_input_removal.cpp
+++ b/tests/test_issue37_pfb_input_removal.cpp
@@ -1,0 +1,76 @@
+// Regression test for GitHub issue #37:
+// "Segmentation Fault when removing PFB Channelizer input"
+//
+// Root cause: NodeGraphWidget::onRemoveNode (app.cpp) destroys the removed
+// component's engine (and its owned SignalNode/Spectrum outputs) synchronously
+// mid-frame, inside draw_ui(). Downstream components that had wired
+// node().inputs[k] to point at the removed engine's Spectrum output were only
+// re-wired at the *start* of update_dsp(), which does not run again until the
+// next frame. Any widget that dereferences node().inputs[] directly while
+// drawing later in the same frame (PFBChannelizerWidget::draw()/rebuildCache())
+// therefore used a dangling pointer into freed memory -> segfault.
+//
+// Fix: RfSimulatorApp::onRemoveNode now calls the new rewireInputs() helper
+// immediately after ComponentRegistry::remove(), so every surviving
+// component's node().inputs[] reflects the current graph topology (nulled out
+// for any severed source) before draw_ui() continues rendering widgets.
+#include "adc_engine.h"
+#include "app.h"
+#include "imgui.h"
+#include "imnodes.h"
+#include "implot.h"
+#include "pfb_channelizer_engine.h"
+#include "signal_generator_engine.h"
+#include <catch2/catch_test_macros.hpp>
+
+struct ImGuiFixture {
+    ImGuiFixture() {
+        ImGui::CreateContext();
+        ImPlot::CreateContext();
+        ImNodes::CreateContext();
+    }
+    ~ImGuiFixture() {
+        ImNodes::DestroyContext();
+        ImPlot::DestroyContext();
+        ImGui::DestroyContext();
+    }
+};
+
+TEST_CASE_METHOD(ImGuiFixture,
+                 "Removing an upstream node immediately nulls downstream dangling input "
+                 "pointers (issue #37)",
+                 "[app][regression][issue37]") {
+    RfSimulatorApp app;
+    app.newProject(); // start from an empty graph
+
+    auto &gen = app.testComponents().add<SignalGeneratorEngine>(10001, app.testGraphEngine());
+    auto &adc = app.testComponents().add<AdcEngine>(10002, app.testGraphEngine());
+    auto &pfb = app.testComponents().add<PFBChannelizerEngine>(10003, app.testGraphEngine());
+
+    app.testGraphEngine().addLink(gen.outputPinId(), adc.inputPinId());
+    app.testGraphEngine().addLink(adc.outputPinId(), pfb.inputPinId());
+
+    // Normal frame: wires PFB's input to the ADC's output Spectrum.
+    app.update_dsp();
+    REQUIRE(pfb.node().inputs[0] == &adc.node().outputs[0]);
+
+    int adc_graph_id = adc.graphNodeId();
+    REQUIRE(app.testGraphWidget().onRemoveNode);
+
+    // Simulate the user deleting the ADC node mid-frame (as the node graph
+    // widget's context menu / Delete key / InspectorPanel "Delete" button do),
+    // which synchronously destroys the AdcEngine and its owned SignalNode.
+    app.testGraphWidget().onRemoveNode(adc_graph_id);
+
+    // The ADC engine (and the Spectrum object pfb.node().inputs[0] pointed at)
+    // has now been freed. Without the fix this pointer would still be
+    // dangling until the *next* update_dsp() call. The fix must null it out
+    // synchronously so any widget drawn later in this same frame
+    // (PFBChannelizerWidget, InspectorPanel) never dereferences freed memory.
+    REQUIRE(pfb.node().inputs[0] == nullptr);
+
+    // Sanity: a normal update_dsp() afterwards should not crash and should
+    // reflect the severed link (PFB produces no output without an input).
+    app.update_dsp();
+    REQUIRE(pfb.node().inputs[0] == nullptr);
+}


### PR DESCRIPTION
## Summary

Fix a use-after-free segfault: deleting an upstream node (e.g. an RF ADC feeding a PFB Channelizer) freed the node's `SignalNode` synchronously mid-`draw_ui()`, leaving downstream components' `node().inputs[]` pointers dangling until the *next* frame's rewire — any widget dereferencing that pointer during the same frame's draw (`PFBChannelizerWidget`) crashed.

## Related issue

Closes #37

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI

## Test plan

- [x] `cmake -B build -G Ninja && cmake --build build`
- [x] `ctest --test-dir build --output-on-failure`
- [x] Manual verification steps:
  - New regression test (`tests/test_issue37_pfb_input_removal.cpp`) builds Generator→ADC→PFB, wires inputs via `update_dsp()`, then invokes the same `onRemoveNode` callback the UI uses on the ADC node, and asserts the PFB's `node().inputs[0]` is nulled **immediately** rather than left dangling.
  - Confirmed the test fails (dangling non-null pointer) against the pre-fix code (`git stash` on `app.cpp`/`app.h`), and passes with the fix.
  - Full existing suite green: `tests.exe` (217 cases / 65522 assertions), `test_extensions`, `test_component_authoring`, `test_attenuator`, `test_combiner`.
  - Full `tiny-rf-simulator` app target builds and links cleanly.

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran `clang-format -i` on changed files (via `scripts/format.sh`)
- [x] I added or updated tests where appropriate
- [x] Existing tests still pass

## Details

`RfSimulatorApp::update_dsp()`'s signal-routing loop is extracted into `RfSimulatorApp::rewireInputs()`. `onRemoveNode` now calls `rewireInputs()` immediately after `ComponentRegistry::remove()`, so every surviving component's `node().inputs[]` reflects the current graph topology (nulled for any severed source) before the rest of that frame's `draw_ui()` continues rendering. This closes the dangling-pointer window for every widget that reads `node().inputs[]` directly during draw (PFB channelizer grid, and similarly the inspector panel's input-frequency readout), not just the reported PFB crash.

Also documents the new safety contract in `app/AGENTS.md`.
