### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.20)
 
-project (RfSimulator VERSION 0.15.0)
+project (RfSimulator VERSION 0.16.0)
 
 # FetchContent'd dependencies below call their own project() commands, which
 # resets PROJECT_VERSION (and _MAJOR/_MINOR/_PATCH) for the remainder of this


### PR DESCRIPTION
Bumps `CMakeLists.txt` project version 0.15.0 -> 0.16.0 for the next release, following #40 (real-domain spectrum Euler/conjugate-symmetry fix). Tag `v0.16.0` will be created on this commit once merged, triggering `release.yml`.