### PR TITLE
fix: mark project dirty on every onAdd callback (#50)

### DIFF
--- a/app/include/app.h
+++ b/app/include/app.h
@@ -97,6 +97,10 @@ class RfSimulatorApp {
     void openEditComponentForm(const ComponentDefinition &def);
     void drawComponentFormModal();
     bool saveComponentForm();
+    // Shared body for the NodeGraphWidget onAdd* callbacks: create the engine,
+    // place it at the requested editor-space position, and mark the project
+    // dirty so unsaved-changes prompts (New/Open/Exit) are not suppressed.
+    template <typename T> T &addComponent(ImVec2 pos);
     NodeGraphEngine m_graph_engine;
     ViewManager m_view_manager;
     SpectrumAnalyzerEngine m_spectrum_engine;

--- a/app/src/app.cpp
+++ b/app/src/app.cpp
@@ -37,77 +37,27 @@ static std::string sanitizePathSegment(const std::string &s, const std::string &
 RfSimulatorApp::RfSimulatorApp() : m_components(m_graph_engine, m_view_manager) {
     m_graph_widget = std::make_unique<NodeGraphWidget>(m_graph_engine);
     m_graph_widget->onAddGenerator = [this](ImVec2 pos) {
-        auto &comp = m_components.add<SignalGeneratorEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
-        markDirty();
+        addComponent<SignalGeneratorEngine>(pos);
     };
-    m_graph_widget->onAddAmplifier = [this](ImVec2 pos) {
-        auto &comp = m_components.add<AmplifierEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
-        markDirty();
-    };
-    m_graph_widget->onAddSplitter = [this](ImVec2 pos) {
-        auto &comp = m_components.add<SplitterEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
-        markDirty();
-    };
-    m_graph_widget->onAddMixer = [this](ImVec2 pos) {
-        auto &comp = m_components.add<MixerEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
-        markDirty();
-    };
+    m_graph_widget->onAddAmplifier = [this](ImVec2 pos) { addComponent<AmplifierEngine>(pos); };
+    m_graph_widget->onAddSplitter = [this](ImVec2 pos) { addComponent<SplitterEngine>(pos); };
+    m_graph_widget->onAddMixer = [this](ImVec2 pos) { addComponent<MixerEngine>(pos); };
 
-    m_graph_widget->onAddAdc = [this](ImVec2 pos) {
-        auto &comp = m_components.add<AdcEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
-        markDirty();
-    };
+    m_graph_widget->onAddAdc = [this](ImVec2 pos) { addComponent<AdcEngine>(pos); };
     m_graph_widget->onAddPFB = [this](ImVec2 pos) {
-        auto &pfb = m_components.add<PFBChannelizerEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(pfb.graphNodeId(), pos);
+        auto &pfb = addComponent<PFBChannelizerEngine>(pos);
         m_iq_widgets.push_back(std::make_unique<IQPlotWidget>(pfb));
         m_show_iq_pfbs.push_back(
             m_state.loadBool("WindowState", ("IQPlot_" + std::to_string(pfb.id())).c_str(), true));
         m_pfb_grid_widgets.push_back(std::make_unique<PFBChannelizerWidget>(pfb));
         m_show_pfb_grids.push_back(
             m_state.loadBool("WindowState", ("PFBGrid_" + std::to_string(pfb.id())).c_str(), true));
-        markDirty();
     };
-    m_graph_widget->onAddCoaxCable = [this](ImVec2 pos) {
-        auto &comp = m_components.add<CoaxCableEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
-        markDirty();
-    };
-    m_graph_widget->onAddEqualizer = [this](ImVec2 pos) {
-        auto &comp = m_components.add<EqualizerEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
-    };
-    m_graph_widget->onAddIdealFilter = [this](ImVec2 pos) {
-        auto &comp = m_components.add<IdealFilterEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
-        markDirty();
-    };
-    m_graph_widget->onAddAttenuator = [this](ImVec2 pos) {
-        auto &comp = m_components.add<AttenuatorEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
-        markDirty();
-    };
-    m_graph_widget->onAddCombiner = [this](ImVec2 pos) {
-        auto &comp = m_components.add<CombinerEngine>(m_next_component_id++, m_graph_engine);
-        ImNodes::EditorContextSet(m_graph_widget->context());
-        ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
-        markDirty();
-    };
+    m_graph_widget->onAddCoaxCable = [this](ImVec2 pos) { addComponent<CoaxCableEngine>(pos); };
+    m_graph_widget->onAddEqualizer = [this](ImVec2 pos) { addComponent<EqualizerEngine>(pos); };
+    m_graph_widget->onAddIdealFilter = [this](ImVec2 pos) { addComponent<IdealFilterEngine>(pos); };
+    m_graph_widget->onAddAttenuator = [this](ImVec2 pos) { addComponent<AttenuatorEngine>(pos); };
+    m_graph_widget->onAddCombiner = [this](ImVec2 pos) { addComponent<CombinerEngine>(pos); };
     m_graph_widget->onNodeMoved = [this]() { markDirty(); };
     m_graph_widget->onLinkChanged = [this]() { markDirty(); };
     m_graph_widget->onRemoveNode = [this](int id) {
@@ -177,6 +127,14 @@ RfSimulatorApp::RfSimulatorApp() : m_components(m_graph_engine, m_view_manager) 
     m_graph_widget->syncNodesFromEngine();
 
     load_window_states();
+}
+
+template <typename T> T &RfSimulatorApp::addComponent(ImVec2 pos) {
+    auto &comp = m_components.add<T>(m_next_component_id++, m_graph_engine);
+    ImNodes::EditorContextSet(m_graph_widget->context());
+    ImNodes::SetNodeEditorSpacePos(comp.graphNodeId(), pos);
+    markDirty();
+    return comp;
 }
 
 void RfSimulatorApp::load_window_states() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,13 @@ target_link_libraries(test_issue37_pfb_input_removal PRIVATE
 )
 target_compile_definitions(test_issue37_pfb_input_removal PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 add_test(NAME test_issue37_pfb_input_removal COMMAND test_issue37_pfb_input_removal WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_executable(test_add_component_dirty test_add_component_dirty.cpp)
+target_link_libraries(test_add_component_dirty PRIVATE
+    simulator::app
+    Catch2::Catch2WithMain
+)
+target_compile_definitions(test_add_component_dirty PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+add_test(NAME test_add_component_dirty COMMAND test_add_component_dirty WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_executable(test_signal_domain test_signal_domain.cpp)
 target_link_libraries(test_signal_domain PRIVATE
     common

--- a/tests/test_add_component_dirty.cpp
+++ b/tests/test_add_component_dirty.cpp
@@ -1,0 +1,70 @@
+// Regression test for GitHub issue #50:
+// "Adding an Equalizer never calls markDirty() - unsaved-changes prompt suppressed"
+//
+// onAddEqualizer was the only onAdd* callback missing markDirty(), so a user who
+// added an Equalizer node and then hit Ctrl+N / Ctrl+O / Exit never saw the
+// unsaved-changes modal — the node (and any other unsaved edits) was silently
+// discarded. Fix: all component-add callbacks route through
+// RfSimulatorApp::addComponent<T>(), which always marks the project dirty.
+// This test pins that contract for every current and future onAdd* callback.
+#include "app.h"
+#include "imgui.h"
+#include "imnodes.h"
+#include "implot.h"
+#include <catch2/catch_test_macros.hpp>
+#include <functional>
+
+struct ImGuiFixture {
+    ImGuiFixture() {
+        ImGui::CreateContext();
+        ImPlot::CreateContext();
+        ImNodes::CreateContext();
+    }
+    ~ImGuiFixture() {
+        ImNodes::DestroyContext();
+        ImPlot::DestroyContext();
+        ImGui::DestroyContext();
+    }
+};
+
+TEST_CASE_METHOD(ImGuiFixture, "Every onAdd* callback marks the project dirty (issue #50)",
+                 "[app][regression][issue50]") {
+    RfSimulatorApp app;
+    app.newProject(); // start from an empty, clean graph
+    REQUIRE_FALSE(app.isDirty());
+    REQUIRE(app.componentCount() == 0);
+
+    NodeGraphWidget &widget = app.testGraphWidget();
+    const ImVec2 pos(10.0f, 10.0f);
+
+    struct AddCase {
+        const char *name;
+        std::function<void(ImVec2)> cb;
+    };
+    const AddCase cases[] = {
+        {"Generator", widget.onAddGenerator},
+        {"Amplifier", widget.onAddAmplifier},
+        {"Splitter", widget.onAddSplitter},
+        {"Mixer", widget.onAddMixer},
+        {"ADC", widget.onAddAdc},
+        {"PFB", widget.onAddPFB},
+        {"Coax Cable", widget.onAddCoaxCable},
+        {"Equalizer", widget.onAddEqualizer},
+        {"Ideal Filter", widget.onAddIdealFilter},
+        {"Attenuator", widget.onAddAttenuator},
+        {"Combiner", widget.onAddCombiner},
+    };
+
+    for (const auto &c : cases) {
+        INFO("onAdd" << c.name);
+        REQUIRE_FALSE(app.isDirty());
+        const size_t before = app.componentCount();
+        c.cb(pos);
+        // Every add must dirty the project — otherwise New/Open/Exit silently
+        // discards the new node because the unsaved-changes modal never appears.
+        REQUIRE(app.isDirty());
+        REQUIRE(app.componentCount() == before + 1);
+        app.newProject(); // reset to a clean slate for the next callback
+        REQUIRE_FALSE(app.isDirty());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the only `onAdd*` callback missing `markDirty()`: adding an Equalizer node never set the dirty flag, so Ctrl+N / Ctrl+O / Exit silently discarded the node because the unsaved-changes modal never appeared.

Per the issue's suggestion, the 11 near-identical `onAdd*` lambdas were extracted into a single `RfSimulatorApp::addComponent<T>(ImVec2 pos)` helper that always marks the project dirty, so the pattern cannot diverge again.

## Related issue

Closes #50

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI

## Test plan

- [x] `cmake --build build` (targets `test_add_component_dirty`, `test_issue37_pfb_input_removal`, `test_extensions`, `tests`)
- [x] `build/bin/test_add_component_dirty.exe` — 46/46 assertions pass; fails pre-fix on the Equalizer iteration
- [x] `build/bin/test_issue37_pfb_input_removal.exe` — passes (4 assertions)
- [x] `build/bin/tests.exe "[project_file]"` — passes (70 assertions, 11 cases)
- [x] `clang-format-18 --dry-run --Werror` on changed C++ files — clean
- [x] Manual verification steps (if applicable): N/A — covered by the new regression test firing every `onAdd*` callback

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran `clang-format -i` on changed files
- [x] I added or updated tests where appropriate
- [x] Existing tests still pass

## Notes

- New test `tests/test_add_component_dirty.cpp` is a standalone executable (not added to the main `tests` binary) per the MinGW-w64 test-registration ceiling documented in `tests/AGENTS.md`.
- DOX pass done: `app/AGENTS.md` already documents the dirty-tracking contract this fix enforces; `tests/AGENTS.md` already documents the standalone-test pattern. No doc changes needed.
