### PR TITLE
fix: propagate Spectrum::fs_Hz through pass-through engines

### DIFF
--- a/amplifier/src/amplifier_engine.cpp
+++ b/amplifier/src/amplifier_engine.cpp
@@ -138,6 +138,7 @@ void AmplifierEngine::update(double dt) {
 
     out.tones = in_ptr ? in_ptr->tones : std::vector<Spectrum::Tone>{};
     out.is_complex_baseband = in_ptr ? in_ptr->is_complex_baseband : false;
+    out.fs_Hz = in_ptr ? in_ptr->fs_Hz : 0.0;
     for (auto &t : out.tones) {
         t.power_dBm += m_gain_dB;
     }

--- a/coax/src/coax_cable_engine.cpp
+++ b/coax/src/coax_cable_engine.cpp
@@ -68,6 +68,7 @@ void CoaxCableEngine::update(double dt) {
 
     out.tones = in_ptr ? in_ptr->tones : std::vector<Spectrum::Tone>{};
     out.is_complex_baseband = in_ptr ? in_ptr->is_complex_baseband : false;
+    out.fs_Hz = in_ptr ? in_ptr->fs_Hz : 0.0;
 
     const CableSpec &p = preset();
     const double max_f_Hz = p.max_freq_GHz * 1e9;

--- a/mixer/src/mixer_engine.cpp
+++ b/mixer/src/mixer_engine.cpp
@@ -38,6 +38,7 @@ void MixerEngine::update(double dt) {
     // Frequency conversion: each input tone produces sum and difference
     out.tones.clear();
     out.is_complex_baseband = in_ptr ? in_ptr->is_complex_baseband : false;
+    out.fs_Hz = in_ptr ? in_ptr->fs_Hz : 0.0;
     if (in_ptr) {
         for (const auto &tone : in_ptr->tones) {
             Spectrum::Tone lower;

--- a/splitter/src/splitter_engine.cpp
+++ b/splitter/src/splitter_engine.cpp
@@ -48,6 +48,7 @@ void SplitterEngine::update(double dt) {
 
         out.tones = in_ptr ? in_ptr->tones : std::vector<Spectrum::Tone>{};
         out.is_complex_baseband = in_ptr ? in_ptr->is_complex_baseband : false;
+        out.fs_Hz = in_ptr ? in_ptr->fs_Hz : 0.0;
         for (auto &t : out.tones) {
             t.power_dBm -= SPLIT_LOSS_DB;
         }

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -9,7 +9,7 @@ Own the Catch2 v3.4.0 unit test suite and ImGui test engine UI tests. Verify all
 - **test_main.cpp** — Catch2 test runner (Catch2::Catch2WithMain linked)
 - **test_*.cpp** — Per-module test files, one per engine/component under test
 - **test_bench_dsp.cpp** — Dirty/clean performance benchmarks for DSP engines
-- **test_signal_domain.cpp** — Standalone executable for `Spectrum::is_complex_baseband`/domain-flag propagation tests across all engines (spans modules, so it doesn't fit the one-file-per-component pattern)
+- **test_signal_domain.cpp** — Standalone executable for cross-engine `Spectrum` propagation tests (`is_complex_baseband`, `fs_Hz`) and post-ADC chain integration tests (ADC → mixer/amp → PFB) (spans modules, so it doesn't fit the one-file-per-component pattern)
 - **CMakeLists.txt** — Links all simulator module targets; test files listed explicitly, plus several standalone executables (see below)
 
 ## Local Contracts

--- a/tests/test_signal_domain.cpp
+++ b/tests/test_signal_domain.cpp
@@ -418,3 +418,170 @@ TEST_CASE("SpectrumAnalyzer: complex-baseband tone renders unchanged (no mirrori
     // own -20 dBm and below the would-be mirror power of ~-23 dBm).
     REQUIRE(trace[10] < -50.0);
 }
+
+// ---- fs_Hz propagation (issue #43) ----
+
+TEST_CASE("Mixer: propagates fs_Hz", "[domain][mixer]") {
+    NodeGraphEngine graph;
+    MixerEngine mixer(0, graph);
+
+    Spectrum in;
+    in.frequencies = {1e9, 2e9};
+    in.tones = {{1e9, -10.0, 0.0}};
+    in.noise_total_W.assign(2, 1e-21);
+    in.fs_Hz = 500e6;
+
+    mixer.node().inputs[0] = &in;
+    mixer.update(0.0);
+
+    REQUIRE(mixer.node().outputs[0].fs_Hz == Approx(500e6));
+}
+
+TEST_CASE("Splitter: propagates fs_Hz to both outputs", "[domain][splitter]") {
+    NodeGraphEngine graph;
+    SplitterEngine splitter(0, graph);
+
+    Spectrum in;
+    in.frequencies = {1e9, 2e9};
+    in.tones = {{1e9, -10.0, 0.0}};
+    in.noise_total_W.assign(2, 1e-21);
+    in.fs_Hz = 500e6;
+
+    splitter.node().inputs[0] = &in;
+    splitter.update(0.0);
+
+    REQUIRE(splitter.node().outputs[0].fs_Hz == Approx(500e6));
+    REQUIRE(splitter.node().outputs[1].fs_Hz == Approx(500e6));
+}
+
+TEST_CASE("CoaxCable: propagates fs_Hz", "[domain][coax]") {
+    NodeGraphEngine graph;
+    CoaxCableEngine coax(0, graph);
+
+    Spectrum in;
+    in.frequencies = {1e9, 2e9};
+    in.tones = {{1e9, -10.0, 0.0}};
+    in.noise_total_W.assign(2, 1e-21);
+    in.fs_Hz = 500e6;
+
+    coax.node().inputs[0] = &in;
+    coax.update(0.0);
+
+    REQUIRE(coax.node().outputs[0].fs_Hz == Approx(500e6));
+}
+
+TEST_CASE("Amplifier: propagates fs_Hz (ideal gain mode)", "[domain][amplifier]") {
+    NodeGraphEngine graph;
+    AmplifierEngine amp(0, graph);
+    amp.setGain_dB(10.0);
+
+    Spectrum in;
+    in.frequencies = {1e9, 2e9};
+    in.tones = {{1e9, -10.0, 0.0}};
+    in.noise_total_W.assign(2, 1e-21);
+    in.fs_Hz = 500e6;
+
+    amp.node().inputs[0] = &in;
+    amp.update(0.0);
+
+    REQUIRE(amp.node().outputs[0].fs_Hz == Approx(500e6));
+}
+
+TEST_CASE("Amplifier: propagates fs_Hz (S-param mode)", "[domain][amplifier]") {
+    NodeGraphEngine graph;
+    AmplifierEngine amp(0, graph);
+    amp.setSParamFilepath(amplifierS2pPath());
+    REQUIRE(amp.sparamLoaded());
+
+    Spectrum in;
+    in.frequencies = {1e9, 2e9};
+    in.tones = {{1e9, -10.0, 0.0}};
+    in.noise_total_W.assign(2, 1e-21);
+    in.fs_Hz = 500e6;
+
+    amp.node().inputs[0] = &in;
+    amp.update(0.0);
+
+    REQUIRE(amp.node().outputs[0].fs_Hz == Approx(500e6));
+}
+
+// Real multi-engine post-ADC chains: fs_Hz must reach the PFB and channels must be populated
+// without any manual setFs_Hz() (issue #43 regression tests).
+
+static bool anyChannelHasContent(const PFBChannelizerEngine &pfb) {
+    for (const auto &ch : pfb.channels()) {
+        if (!ch.tones.empty() || ch.noise_W > 0.0)
+            return true;
+    }
+    return false;
+}
+
+TEST_CASE("ADC+Mixer: fs_Hz reaches PFB and channels are populated", "[domain][adc][mixer][pfb]") {
+    NodeGraphEngine graph;
+    AdcEngine adc(0, graph);
+    adc.setFs_Hz(1e9);
+
+    Spectrum in;
+    in.frequencies.resize(101);
+    for (int i = 0; i < 101; ++i)
+        in.frequencies[i] = i * 5e6; // 0..500 MHz
+    in.noise_W.assign(101, 1e-20);
+    in.noise_added_W.assign(101, 0.0);
+    in.noise_total_W.assign(101, 1e-20);
+    in.tones.push_back({250e6, -20.0, 0.0}); // Fs/4 -> DDC maps to DC
+
+    adc.node().inputs[0] = &in;
+    adc.update(0.0);
+    REQUIRE(adc.node().outputs[0].fs_Hz == Approx(500e6)); // Fs/2
+
+    MixerEngine mix(1, graph);
+    mix.setLoFreq_Hz(100e6);
+    mix.node().inputs[0] = &adc.node().outputs[0];
+    mix.update(0.0);
+    REQUIRE(mix.node().outputs[0].fs_Hz == Approx(500e6));
+
+    PFBChannelizerEngine pfb(2, graph);
+    pfb.setChannelCount(32);
+    pfb.node().inputs[0] = &mix.node().outputs[0];
+    pfb.update(0.0);
+
+    REQUIRE(pfb.fs_Hz() == Approx(500e6));
+    REQUIRE(!pfb.node().outputs[0].frequencies.empty());
+    REQUIRE(pfb.channels().size() == 32);
+    REQUIRE(anyChannelHasContent(pfb));
+}
+
+TEST_CASE("ADC+Amplifier(gain): fs_Hz reaches PFB and channels are populated",
+          "[domain][adc][amp][pfb]") {
+    NodeGraphEngine graph;
+    AdcEngine adc(0, graph);
+    adc.setFs_Hz(1e9);
+
+    Spectrum in;
+    in.frequencies.resize(101);
+    for (int i = 0; i < 101; ++i)
+        in.frequencies[i] = i * 5e6; // 0..500 MHz
+    in.noise_W.assign(101, 1e-20);
+    in.noise_added_W.assign(101, 0.0);
+    in.noise_total_W.assign(101, 1e-20);
+    in.tones.push_back({250e6, -20.0, 0.0}); // Fs/4 -> DDC maps to DC
+
+    adc.node().inputs[0] = &in;
+    adc.update(0.0);
+
+    AmplifierEngine amp(1, graph);
+    amp.setGain_dB(10.0);
+    amp.node().inputs[0] = &adc.node().outputs[0];
+    amp.update(0.0);
+    REQUIRE(amp.node().outputs[0].fs_Hz == Approx(500e6));
+
+    PFBChannelizerEngine pfb(2, graph);
+    pfb.setChannelCount(32);
+    pfb.node().inputs[0] = &amp.node().outputs[0];
+    pfb.update(0.0);
+
+    REQUIRE(pfb.fs_Hz() == Approx(500e6));
+    REQUIRE(!pfb.node().outputs[0].frequencies.empty());
+    REQUIRE(pfb.channels().size() == 32);
+    REQUIRE(anyChannelHasContent(pfb));
+}


### PR DESCRIPTION
## Summary

Fixes issue #43: engines in the post-ADC chain (`mixer`, `splitter`, `coax`, amplifier gain branch) never propagated `Spectrum::fs_Hz`, so ADC → mixer/coax/splitter/amp(gain) → PFB chains delivered `fs_Hz == 0` to the PFB, which then emitted empty output. Adds one line per engine — `out.fs_Hz = in_ptr ? in_ptr->fs_Hz : 0.0;` — placed exactly where `is_complex_baseband` is propagated, plus cross-engine propagation and chain tests.

## Related issue

Closes #43

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI

## Test plan

- [x] `cmake --build build` — full project builds clean
- [x] `build/bin/test_signal_domain.exe` — 31 test cases / 64 assertions pass, including 7 new cases:
  - per-engine `fs_Hz` propagation: mixer, splitter (both outputs), coax, amplifier ideal mode, amplifier S-param mode (regression lock)
  - chain integration: ADC → mixer → PFB and ADC → amp(gain) → PFB, asserting `fs_Hz` reaches the PFB (`pfb.fs_Hz() == Fs/2`, no manual `setFs_Hz()`) and channels are non-empty
- [x] `build/bin/tests.exe` — 215 test cases / 65 509 assertions pass (no regressions)
- [x] Regression proof: stashing the four engine fixes makes exactly the 6 new propagation/chain tests fail; restoring them makes all pass
- Note: `ctest` entry #147 ("No test cases matched") is a pre-existing Windows-only artifact — `catch_discover_tests` builds a filter that exceeds the Windows command-line length limit. Reproduced on a fully clean tree (all changes stashed); unrelated to this PR.

## Checklist

- [x] My code follows the existing code style (see `.clang-format`) — pre-commit hook passed using the pinned clang-format 18.1.8
- [x] I ran `clang-format -i` on changed files
- [x] I added or updated tests where appropriate
- [x] Existing tests still pass
