### PR TITLE
Fix S-param mode not reloading on project deserialize

### DIFF
--- a/amplifier/src/amplifier_engine.cpp
+++ b/amplifier/src/amplifier_engine.cpp
@@ -227,8 +227,10 @@ void AmplifierEngine::deserialize(const nlohmann::json &j) {
     if (!j.contains("enable_nonlinear") &&
         (j.contains("oip2_dBm") || j.contains("oip3_dBm") || j.contains("p1db_dBm")))
         m_nonlinear.setEnabled(true);
-    m_sparam_mode = j.value("sparam_mode", false);
     m_sparam_filepath = j.value("sparam_filepath", "");
+    if (!m_sparam_filepath.empty())
+        m_sparam_data.load(m_sparam_filepath);
+    m_sparam_mode = j.value("sparam_mode", false) && m_sparam_data.loaded();
     m_sparam_fwd_idx = j.value("sparam_fwd_idx", 0);
     m_dirty = true;
 }

--- a/app/src/app.cpp
+++ b/app/src/app.cpp
@@ -542,10 +542,10 @@ void RfSimulatorApp::update_dsp() {
 
     for (auto *node : m_view_manager.nodes()) {
         if (node) {
-            node->view_enabled =
-                std::find_if(probed_sources.begin(), probed_sources.end(),
-                             [node](const SignalSource &ps) { return ps.node == node; }) !=
-                probed_sources.end();
+            node->view_enabled = std::find_if(probed_sources.begin(), probed_sources.end(),
+                                              [node](const SignalSource &ps) {
+                                                  return ps.node == node;
+                                              }) != probed_sources.end();
         }
     }
 

--- a/attenuator/src/attenuator_engine.cpp
+++ b/attenuator/src/attenuator_engine.cpp
@@ -183,8 +183,10 @@ nlohmann::json AttenuatorEngine::serialize() const {
 void AttenuatorEngine::deserialize(const nlohmann::json &j) {
     m_atten_dB =
         j.contains("atten_dB") ? j["atten_dB"].get<double>() : j.value("attenuation_dB", 0.0);
-    m_sparam_mode = j.value("sparam_mode", false);
     m_sparam_path = j.value("sparam_path", "");
+    if (!m_sparam_path.empty())
+        m_sparam.load(m_sparam_path);
+    m_sparam_mode = j.value("sparam_mode", false) && m_sparam.loaded();
     m_dirty = true;
 }
 

--- a/combiner/src/combiner_engine.cpp
+++ b/combiner/src/combiner_engine.cpp
@@ -63,8 +63,10 @@ nlohmann::json CombinerEngine::serialize() const {
 
 void CombinerEngine::deserialize(const nlohmann::json &j) {
     m_manual_mode = j.value("manual_mode", true);
-    m_sparam_mode = j.value("sparam_mode", false);
     m_sparam_path = j.value("sparam_path", "");
+    if (!m_sparam_path.empty())
+        m_sparam.load(m_sparam_path);
+    m_sparam_mode = j.value("sparam_mode", false) && m_sparam.loaded();
     m_dirty = true;
 }
 

--- a/equalizer/src/equalizer_engine.cpp
+++ b/equalizer/src/equalizer_engine.cpp
@@ -161,14 +161,18 @@ nlohmann::json EqualizerEngine::serialize() const {
             {"ref_freq_Hz", m_ref_freq_Hz},
             {"slope_dB_per_decade", m_slope_dB_per_decade},
             {"sparam_mode", m_sparam_mode},
-            {"sparam_filepath", m_sparam_filepath}};
+            {"sparam_filepath", m_sparam_filepath},
+            {"sparam_fwd_idx", m_sparam_fwd_idx}};
 }
 
 void EqualizerEngine::deserialize(const nlohmann::json &j) {
     m_ref_gain_dB = j.value("ref_gain_dB", 0.0);
     m_ref_freq_Hz = j.value("ref_freq_Hz", 1e9);
     m_slope_dB_per_decade = j.value("slope_dB_per_decade", 0.0);
-    m_sparam_mode = j.value("sparam_mode", false);
     m_sparam_filepath = j.value("sparam_filepath", "");
+    if (!m_sparam_filepath.empty())
+        m_sparam_data.load(m_sparam_filepath);
+    m_sparam_mode = j.value("sparam_mode", false) && m_sparam_data.loaded();
+    m_sparam_fwd_idx = j.value("sparam_fwd_idx", 0);
     m_dirty = true;
 }

--- a/ideal_filter/src/ideal_filter_engine.cpp
+++ b/ideal_filter/src/ideal_filter_engine.cpp
@@ -200,8 +200,10 @@ void IdealFilterEngine::deserialize(const nlohmann::json &j) {
     } else if (j.contains("fc_low_Hz")) {
         setCutoff_Hz(j["fc_low_Hz"].get<double>());
     }
-    m_sparam_mode = j.value("sparam_mode", false);
     m_sparam_filepath = j.value("sparam_filepath", "");
+    if (!m_sparam_filepath.empty())
+        m_sparam_data.load(m_sparam_filepath);
+    m_sparam_mode = j.value("sparam_mode", false) && m_sparam_data.loaded();
     m_sparam_fwd_idx = j.value("sparam_fwd_idx", 0);
     m_dirty = true;
 }

--- a/tests/test_issue42_multi_output.cpp
+++ b/tests/test_issue42_multi_output.cpp
@@ -49,8 +49,7 @@ static int outputPinFor(NodeGraphEngine &graph, SignalNode *node, int port) {
     return -1;
 }
 
-TEST_CASE_METHOD(ImGuiFixture,
-                 "Splitter OUT2 routes to Combiner IN1 with outputs[1] (issue #42)",
+TEST_CASE_METHOD(ImGuiFixture, "Splitter OUT2 routes to Combiner IN1 with outputs[1] (issue #42)",
                  "[app][issue42]") {
     RfSimulatorApp app;
     app.newProject();

--- a/tests/test_project_file.cpp
+++ b/tests/test_project_file.cpp
@@ -438,3 +438,77 @@ TEST_CASE_METHOD(ImGuiFixture, "Round-trip: default component positions are (0,0
     }
     std::remove(path.c_str());
 }
+
+// ---------------------------------------------------------------------------
+// 13 — Issue #44: S-param mode survives save/load for amplifier, ideal filter,
+//      equalizer, attenuator, and combiner. Previously deserialize() restored
+//      sparam_mode/sparam_filepath but never reloaded the Touchstone file, so
+//      a reloaded project silently fell back to ideal/manual mode.
+// ---------------------------------------------------------------------------
+static std::string sparamFixturePath() {
+    return std::string(PROJECT_SOURCE_DIR) +
+           "/component_data/amplifiers/adm-3844psm/ADM-8344PSM_SM_A_25C_De_5V_5V_102mA.s2p";
+}
+
+TEST_CASE_METHOD(ImGuiFixture, "Round-trip: S-param mode survives save/load (issue #44)",
+                 "[project_file][sparam]") {
+    auto path = tempPath();
+    std::remove(path.c_str());
+    const std::string s2p = sparamFixturePath();
+    {
+        RfSimulatorApp app;
+        app.newProject();
+
+        auto &amp = app.testComponents().add<AmplifierEngine>(10001, app.testGraphEngine());
+        amp.setSParamFilepath(s2p);
+        REQUIRE(amp.sparamLoaded());
+
+        auto &flt = app.testComponents().add<IdealFilterEngine>(10002, app.testGraphEngine());
+        flt.setSParamFilepath(s2p);
+        REQUIRE(flt.sparamLoaded());
+
+        auto &eq = app.testComponents().add<EqualizerEngine>(10003, app.testGraphEngine());
+        eq.setSParamFilepath(s2p);
+        REQUIRE(eq.sparamLoaded());
+
+        auto &atten = app.testComponents().add<AttenuatorEngine>(10004, app.testGraphEngine());
+        atten.setSParamFile(s2p);
+        REQUIRE(atten.sParamMode());
+
+        auto &comb = app.testComponents().add<CombinerEngine>(10005, app.testGraphEngine());
+        comb.setSParamFile(s2p);
+        REQUIRE(comb.sParamMode());
+
+        REQUIRE(app.componentCount() == 5);
+        app.saveProject(path);
+    }
+    {
+        RfSimulatorApp app;
+        app.loadProject(path);
+        REQUIRE(app.componentCount() == 5);
+
+        auto amps = app.testComponents().byType<AmplifierEngine>();
+        REQUIRE(amps.size() == 1);
+        CHECK(amps[0]->sparamMode() == true);
+        CHECK(amps[0]->sparamLoaded() == true);
+
+        auto flts = app.testComponents().byType<IdealFilterEngine>();
+        REQUIRE(flts.size() == 1);
+        CHECK(flts[0]->sparamMode() == true);
+        CHECK(flts[0]->sparamLoaded() == true);
+
+        auto eqs = app.testComponents().byType<EqualizerEngine>();
+        REQUIRE(eqs.size() == 1);
+        CHECK(eqs[0]->sparamMode() == true);
+        CHECK(eqs[0]->sparamLoaded() == true);
+
+        auto attens = app.testComponents().byType<AttenuatorEngine>();
+        REQUIRE(attens.size() == 1);
+        CHECK(attens[0]->sParamMode() == true);
+
+        auto combs = app.testComponents().byType<CombinerEngine>();
+        REQUIRE(combs.size() == 1);
+        CHECK(combs[0]->sParamMode() == true);
+    }
+    std::remove(path.c_str());
+}


### PR DESCRIPTION
## Summary
Fixes #44. `deserialize()` in the five S-param-capable engines (Amplifier, IdealFilter, Equalizer, Attenuator, Combiner) restored `sparam_mode`/`sparam_filepath` from the project JSON but never reloaded the Touchstone file. `update()` gates the S-param path on `sparam_mode && sparam_data.loaded()`, so a reloaded project silently fell back to ideal/manual mode while the UI still showed S-param mode as enabled.

## Root cause
Confirmed by reading each engine's `deserialize()`: the loader (`m_sparam_data.load(...)` / `m_sparam.load(...)`) was only ever invoked from the `setSParamFilepath()`/`setSParamFile()` setters used by live UI interaction — never from `deserialize()`, which is also the path used for project load, component cloning, and library-part instantiation.

`EqualizerEngine::serialize()` additionally omitted `sparam_fwd_idx`, which its S-param branch (`equalizer_engine.cpp:51`) depends on.

## Fix
- `amplifier_engine.cpp`, `ideal_filter_engine.cpp`, `equalizer_engine.cpp`: `deserialize()` now reloads `m_sparam_data` from the deserialized filepath and gates `m_sparam_mode` on the actual `loaded()` result (so a stale/missing file now correctly reports mode off instead of on-but-broken). `sparam_fwd_idx` is preserved from JSON, not recomputed.
- `attenuator_engine.cpp`, `combiner_engine.cpp`: same pattern via `m_sparam.load(...)`.
- `equalizer_engine.cpp` `serialize()`: added missing `sparam_fwd_idx` field.

## Test
Added `tests/test_project_file.cpp` case 13 ("Round-trip: S-param mode survives save/load (issue #44)"): builds all 5 component types in S-param mode using the existing `component_data/amplifiers/adm-3844psm/*.s2p` fixture, saves, reloads in a fresh `RfSimulatorApp`, and asserts `sparamMode()`/`sparamLoaded()`/`sParamMode()` are all true post-reload.

## Verification
- Full `tests` suite: 216 test cases, 65530 assertions — pass, no regressions
- `[project_file]` filter: 12 cases, 90 assertions — pass (includes new test)
- `[sparam]` filter: 12 cases, 4057 assertions — pass
- `test_attenuator.exe` / `test_combiner.exe` — pass
- Formatted with clang-format-18 (matches CI)
