### PR TITLE
fix: crash/robustness — malformed project/library JSON, S-param path containment, touchstone OOM caps

### DIFF
--- a/app/src/component_library.cpp
+++ b/app/src/component_library.cpp
@@ -2,12 +2,74 @@
 #include "component_type_registry.h"
 #include "logging_core.h"
 #include <filesystem>
+#include <optional>
 
 #include "amplifier_engine.h"
 #include "component_interface.h"
 #include "component_registry.h"
 #include "node_graph_engine.h"
 #include <fstream>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+// --- Data-file path containment (S1) ----------------------------------------
+// Mirrors extension_manifest.cpp's resolveWithinRoot discipline: a library
+// data-file path is only honored if its canonical form stays inside the
+// library JSON file's directory. Absolute paths outside it, '..' traversal,
+// and unresolvable paths are skipped instead of reading arbitrary files.
+
+bool containsParentTraversal(const fs::path &path) {
+    for (const auto &part : path) {
+        if (part == "..")
+            return true;
+    }
+    return false;
+}
+
+bool pathWithinRoot(const fs::path &root, const fs::path &candidate) {
+    std::error_code ec;
+    const fs::path canonical_root = fs::weakly_canonical(root, ec);
+    if (ec)
+        return false;
+
+    ec.clear();
+    const fs::path canonical_candidate = fs::weakly_canonical(candidate, ec);
+    if (ec)
+        return false;
+
+    auto root_it = canonical_root.begin();
+    auto candidate_it = canonical_candidate.begin();
+    for (; root_it != canonical_root.end(); ++root_it, ++candidate_it) {
+        if (candidate_it == canonical_candidate.end() || *root_it != *candidate_it)
+            return false;
+    }
+    return true;
+}
+
+// Resolve a data-file path from a library definition against the library JSON
+// file's directory. Returns the canonical path on success, or nullopt when the
+// entry must be skipped.
+std::optional<fs::path> resolveDataFilePath(const fs::path &json_dir, const std::string &input) {
+    const fs::path p(input);
+    if (p.empty())
+        return std::nullopt;
+    if (containsParentTraversal(p))
+        return std::nullopt;
+
+    const fs::path candidate = p.is_absolute() ? p : (json_dir / p);
+    if (!pathWithinRoot(json_dir, candidate))
+        return std::nullopt;
+
+    std::error_code ec;
+    const fs::path resolved = fs::weakly_canonical(candidate, ec);
+    if (ec)
+        return std::nullopt;
+    return resolved;
+}
+
+} // namespace
 
 std::vector<ValidationIssue> ComponentLibrary::validate(const std::string &type,
                                                         const nlohmann::json &parameters) const {
@@ -88,39 +150,41 @@ void ComponentLibrary::loadFile(const std::string &filepath) {
     nlohmann::json j;
     try {
         ifs >> j;
-    } catch (const nlohmann::json::parse_error &e) {
-        LOG_WARN("ComponentLibrary: JSON parse error in %s: %s", filepath.c_str(), e.what());
-        return;
-    }
 
-    if (!j.contains("type") || !j.contains("part_number") || !j.contains("parameters")) {
-        LOG_WARN("ComponentLibrary: missing required fields in %s", filepath.c_str());
-        return;
-    }
+        if (!j.contains("type") || !j.contains("part_number") || !j.contains("parameters")) {
+            LOG_WARN("ComponentLibrary: missing required fields in %s", filepath.c_str());
+            return;
+        }
 
-    ComponentDefinition def;
-    def.schema_version = j.value("schema_version", 1);
-    def.type = j["type"].get<std::string>();
-    def.part_number = j["part_number"].get<std::string>();
-    def.manufacturer = j.value("manufacturer", "");
-    def.description = j.value("description", "");
-    def.parameters = j["parameters"];
-    def.test_conditions = j.value("test_conditions", nlohmann::json::object());
-    def.notes = j.value("notes", "");
-    def.source_path = filepath;
-    def.issues = validate(def.type, def.parameters);
+        ComponentDefinition def;
+        def.schema_version = j.value("schema_version", 1);
+        def.type = j["type"].get<std::string>();
+        def.part_number = j["part_number"].get<std::string>();
+        def.manufacturer = j.value("manufacturer", "");
+        def.description = j.value("description", "");
+        def.parameters = j["parameters"];
+        def.test_conditions = j.value("test_conditions", nlohmann::json::object());
+        def.notes = j.value("notes", "");
+        def.source_path = filepath;
+        def.issues = validate(def.type, def.parameters);
 
-    // Parse data_files array if present
-    if (j.contains("data_files") && j["data_files"].is_array()) {
-        for (const auto &df : j["data_files"]) {
-            if (df.contains("type") && df.contains("path")) {
-                def.data_files.push_back(
-                    {df["type"].get<std::string>(), df["path"].get<std::string>()});
+        // Parse data_files array if present
+        if (j.contains("data_files") && j["data_files"].is_array()) {
+            for (const auto &df : j["data_files"]) {
+                if (df.contains("type") && df.contains("path")) {
+                    def.data_files.push_back(
+                        {df["type"].get<std::string>(), df["path"].get<std::string>()});
+                }
             }
         }
-    }
 
-    m_definitions.push_back(std::move(def));
+        m_definitions.push_back(std::move(def));
+    } catch (const nlohmann::json::exception &e) {
+        // Covers parse_error AND type_error (e.g. a required field present but
+        // wrong-typed). A malformed library entry is skipped, not fatal.
+        LOG_WARN("ComponentLibrary: invalid JSON in %s: %s", filepath.c_str(), e.what());
+        return;
+    }
 }
 
 std::vector<const ComponentDefinition *> ComponentLibrary::all() const {
@@ -136,10 +200,16 @@ void ComponentLibrary::scan(const std::string &directory) {
     namespace fs = std::filesystem;
     if (!fs::exists(directory))
         return;
-    for (const auto &entry : fs::recursive_directory_iterator(directory)) {
-        if (entry.is_regular_file() && entry.path().extension() == ".json") {
-            loadFile(entry.path().string());
+    try {
+        for (const auto &entry : fs::recursive_directory_iterator(directory)) {
+            if (entry.is_regular_file() && entry.path().extension() == ".json") {
+                loadFile(entry.path().string());
+            }
         }
+    } catch (const fs::filesystem_error &e) {
+        // An unreadable subtree (e.g. permission denied) must not abort the
+        // scan of the remaining roots.
+        LOG_WARN("ComponentLibrary: skipping unreadable directory in scan: %s", e.what());
     }
 }
 
@@ -172,18 +242,25 @@ IComponentEngine *ComponentLibrary::instantiate(const ComponentDefinition &def, 
             if (df.type == "s_parameters" && amp) {
                 std::filesystem::path json_dir =
                     std::filesystem::path(def.source_path).parent_path();
-                std::filesystem::path sparam_path = json_dir / df.path;
-                amp->setSParamFilepath(sparam_path.string());
+                // S1: the data-file path must stay within the library JSON
+                // file's directory; absolute paths and '..' escapes are
+                // rejected (skipped) rather than reading arbitrary files.
+                if (auto sparam_path = resolveDataFilePath(json_dir, df.path)) {
+                    amp->setSParamFilepath(sparam_path->string());
 
-                if (amp->sparamLoaded()) {
-                    LOG_INFO("Loaded S-param file for %s: %s", def.part_number.c_str(),
-                             sparam_path.string().c_str());
-                } else {
-                    LOG_WARN("Failed to load S-param file for %s: %s (falling back to "
-                             "single-point params)",
-                             def.part_number.c_str(), sparam_path.string().c_str());
+                    if (amp->sparamLoaded()) {
+                        LOG_INFO("Loaded S-param file for %s: %s", def.part_number.c_str(),
+                                 sparam_path->string().c_str());
+                    } else {
+                        LOG_WARN("Failed to load S-param file for %s: %s (falling back to "
+                                 "single-point params)",
+                                 def.part_number.c_str(), sparam_path->string().c_str());
+                    }
+                    break; // Only load first S-param file
                 }
-                break; // Only load first S-param file
+                LOG_WARN("ComponentLibrary: rejecting S-param data file path '%s' for %s "
+                         "(must stay within the library directory)",
+                         df.path.c_str(), def.part_number.c_str());
             }
         }
     }

--- a/app/src/project_serializer.cpp
+++ b/app/src/project_serializer.cpp
@@ -9,11 +9,120 @@
 #include "pfb_channelizer_engine.h"
 #include "pfb_view_manager.h"
 #include "session_state.h"
+#include <filesystem>
 #include <fstream>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+// --- S-param path containment (S1) -----------------------------------------
+// Mirrors extension_manifest.cpp's resolveWithinRoot discipline: an S-param
+// path read from an untrusted project file is only honored if its canonical
+// form stays inside the project file's directory. Absolute paths outside the
+// project dir, '..' traversal, and unresolvable paths are neutralized at the
+// load boundary before any engine deserializes them.
+
+bool containsParentTraversal(const fs::path &path) {
+    for (const auto &part : path) {
+        if (part == "..")
+            return true;
+    }
+    return false;
+}
+
+bool pathWithinRoot(const fs::path &root, const fs::path &candidate) {
+    std::error_code ec;
+    const fs::path canonical_root = fs::weakly_canonical(root, ec);
+    if (ec)
+        return false;
+
+    ec.clear();
+    const fs::path canonical_candidate = fs::weakly_canonical(candidate, ec);
+    if (ec)
+        return false;
+
+    auto root_it = canonical_root.begin();
+    auto candidate_it = canonical_candidate.begin();
+    for (; root_it != canonical_root.end(); ++root_it, ++candidate_it) {
+        if (candidate_it == canonical_candidate.end() || *root_it != *candidate_it)
+            return false;
+    }
+    return true;
+}
+
+// Resolve an S-param path from an untrusted project file against the project
+// directory. Returns the canonical absolute path on success, or nullopt when
+// the path must be neutralized (absolute outside the project dir, '..'
+// traversal, or unresolvable).
+std::optional<std::string> resolveSparamPath(const fs::path &project_dir,
+                                             const std::string &input) {
+    const fs::path p(input);
+    if (p.empty())
+        return std::nullopt;
+    if (containsParentTraversal(p))
+        return std::nullopt;
+
+    const fs::path candidate = p.is_absolute() ? p : (project_dir / p);
+    if (!pathWithinRoot(project_dir, candidate))
+        return std::nullopt;
+
+    std::error_code ec;
+    const fs::path resolved = fs::weakly_canonical(candidate, ec);
+    if (ec)
+        return std::nullopt;
+    return resolved.string();
+}
+
+// Load boundary: rewrite S-param path params in-place. Contained paths are
+// resolved to their canonical absolute form (the engine loads them, and the
+// save boundary re-relativizes them for round-trip); paths that escape the
+// project dir are neutralized to "" with a warning.
+void resolveSparamParams(nlohmann::json &params, const fs::path &project_dir) {
+    if (!params.is_object())
+        return;
+    for (const char *key : {"sparam_filepath", "sparam_path"}) {
+        if (!params.contains(key) || !params[key].is_string())
+            continue;
+        const std::string value = params[key].get<std::string>();
+        if (value.empty())
+            continue;
+        if (const auto resolved = resolveSparamPath(project_dir, value)) {
+            params[key] = *resolved;
+        } else {
+            LOG_WARN("Project S-param path rejected (outside project dir): %s", value.c_str());
+            params[key] = "";
+        }
+    }
+}
+
+// Save boundary: keep the project file portable by persisting S-param paths
+// relative to the project directory. Absolute paths the user configured that
+// stay inside the project dir are re-written relative; anything else is left
+// untouched (load-side containment already guards untrusted project files).
+void relativizeSparamParams(nlohmann::json &params, const fs::path &project_dir) {
+    if (!params.is_object())
+        return;
+    for (const char *key : {"sparam_filepath", "sparam_path"}) {
+        if (!params.contains(key) || !params[key].is_string())
+            continue;
+        const fs::path p(params[key].get<std::string>());
+        if (!p.is_absolute() || !pathWithinRoot(project_dir, p))
+            continue;
+        std::error_code ec;
+        const fs::path rel = fs::relative(p, project_dir, ec);
+        if (ec)
+            continue;
+        params[key] = rel.generic_string();
+    }
+}
+
+} // namespace
 
 ProjectSerializer::ProjectSerializer(ComponentRegistry &components, NodeGraphEngine &graph,
                                      NodeGraphWidget &graph_widget, PFBViewManager &pfb_views,
@@ -41,11 +150,14 @@ void ProjectSerializer::save(const std::string &path) {
 
     // Save components by iterating the registry
     nlohmann::json comps_arr = nlohmann::json::array();
+    // S1: S-param paths are persisted relative to the project dir for portability.
+    const fs::path save_project_dir = fs::absolute(fs::path(path)).parent_path();
     for (auto *comp : m_components.all()) {
         nlohmann::json cj;
         const auto *desc = ComponentTypeRegistry::instance().find(comp->type_name());
         cj["type"] = desc ? desc->project_type : "Unknown";
         cj["params"] = comp->serialize();
+        relativizeSparamParams(cj["params"], save_project_dir);
 
         // Save node position via imnodes
         int nid = comp->graphNodeId();
@@ -163,6 +275,21 @@ bool ProjectSerializer::load(const std::string &path) {
         LOG_ERROR("Failed to open project file: %s", path.c_str());
         return false;
     }
+    // Reject oversized files before parsing (e.g. a truncated or corrupted
+    // file could otherwise balloon memory during parse).
+    in.seekg(0, std::ios::end);
+    const std::streamoff file_size = in.tellg();
+    if (file_size > 64 * 1024 * 1024) {
+        LOG_ERROR("Project file too large to load (%lld bytes): %s",
+                  static_cast<long long>(file_size), path.c_str());
+        return false;
+    }
+    in.seekg(0, std::ios::beg);
+
+    // S1: the project file's directory is the containment root for S-param
+    // paths referenced from this project.
+    const fs::path project_dir = fs::absolute(fs::path(path)).parent_path();
+
     nlohmann::json root;
     try {
         in >> root;
@@ -170,126 +297,154 @@ bool ProjectSerializer::load(const std::string &path) {
         LOG_ERROR("Invalid project file: %s", e.what());
         return false;
     }
-
-    reset();
-
-    // Map: type string \u2192 factory lambda
-    std::vector<nlohmann::json::iterator> comp_order;
-    auto &comps = root["components"];
-    for (auto it = comps.begin(); it != comps.end(); ++it)
-        comp_order.push_back(it);
-
-    // Create components in saved order
-    std::vector<int> new_node_ids; // maps saved index \u2192 new graph node ID
-    for (auto &it : comp_order) {
-        auto &cj = *it;
-        std::string type = cj.value("type", "");
-        auto &params = cj["params"];
-
-        const auto *desc = ComponentTypeRegistry::instance().findByProjectType(type);
-        if (!desc) {
-            LOG_WARN("Unknown component type in project file: %s", type.c_str());
-            new_node_ids.push_back(-1);
-            continue;
-        }
-        IComponentEngine *comp = desc->create(m_components, m_graph, m_next_component_id++);
-        comp->deserialize(params);
-        if (desc->type == "pfb") {
-            // Restore IQ plot + PFB grid widgets for this PFB
-            m_pfb_views.addFor(*static_cast<PFBChannelizerEngine *>(comp), m_state);
-        }
-
-        new_node_ids.push_back(comp ? comp->graphNodeId() : -1);
-
-        // Restore position
-        if (comp && cj.contains("pos")) {
-            ImNodes::EditorContextSet(m_graph_widget.context());
-            ImNodes::SetNodeEditorSpacePos(comp->graphNodeId(), ImVec2(cj["pos"].value("x", 0.0f),
-                                                                       cj["pos"].value("y", 0.0f)));
-        }
-
-        // Restore library part number
-        if (comp && cj.contains("part_number"))
-            m_graph.setNodePartNumber(comp->graphNodeId(), cj["part_number"].get<std::string>());
-    }
-    // After restoring all positions, inform the widget so subsequent
-    // syncNodesFromEngine calls (e.g. from saveProject) don't reset them.
-    m_graph_widget.markNodesRegistered();
-
-    // Restore links (saved as component-index + port pairs)
-    auto &saved_links = root["links"];
-    for (const auto &lj : saved_links) {
-        int from_idx = lj.value("from", -1);
-        int to_idx = lj.value("to", -1);
-        int from_port = lj.value("from_port", 0);
-        int to_port = lj.value("to_port", 0);
-        if (from_idx < 0 || to_idx < 0 || static_cast<size_t>(from_idx) >= new_node_ids.size() ||
-            static_cast<size_t>(to_idx) >= new_node_ids.size())
-            continue;
-
-        int from_node = new_node_ids[from_idx];
-        int to_node = new_node_ids[to_idx];
-        if (from_node < 0 || to_node < 0)
-            continue;
-
-        auto *from_comp = m_components.find(from_node);
-        auto *to_comp = m_components.find(to_node);
-        if (!from_comp || !to_comp)
-            continue;
-
-        int start_pin = from_comp->outputPinId(from_port);
-        int end_pin = to_comp->inputPinId(to_port);
-        if (start_pin >= 0 && end_pin >= 0)
-            m_graph.addLink(start_pin, end_pin);
+    if (!root.is_object()) {
+        LOG_ERROR("Invalid project file (root is not a JSON object): %s", path.c_str());
+        return false;
     }
 
-    // Restore probes
-    auto &saved_probes = root["probe_pins"];
-    for (const auto &pj : saved_probes) {
-        int comp_idx = pj.value("comp", -1);
-        int port = pj.value("port", 0);
-        bool is_output = pj.value("is_output", true);
-        if (comp_idx < 0 || static_cast<size_t>(comp_idx) >= m_components.size())
-            continue;
-        auto *comp = m_components.all()[comp_idx];
-        int pin = is_output ? comp->outputPinId(port) : comp->inputPinId(port);
-        if (pin >= 0)
-            m_graph.addProbePin(pin);
-    }
+    try {
+        reset();
 
-    // Restore groups
-    auto &saved_groups = root["groups"];
-    for (const auto &gj : saved_groups) {
-        std::string name = gj.value("name", "Group");
-        std::vector<int> member_ids;
-        for (const auto &mj : gj["member_components"]) {
-            int comp_idx = mj.get<int>();
-            if (comp_idx >= 0 && static_cast<size_t>(comp_idx) < new_node_ids.size() &&
-                new_node_ids[comp_idx] >= 0) {
-                member_ids.push_back(new_node_ids[comp_idx]);
+        // Map: type string \u2192 factory lambda
+        std::vector<nlohmann::json::iterator> comp_order;
+        auto &comps = root["components"];
+        for (auto it = comps.begin(); it != comps.end(); ++it)
+            comp_order.push_back(it);
+
+        // Create components in saved order
+        std::vector<int> new_node_ids; // maps saved index \u2192 new graph node ID
+        size_t comp_index = 0;
+        for (auto &it : comp_order) {
+            auto &cj = *it;
+            const size_t current_index = comp_index++;
+            // One malformed component must not abort the whole load: log it and
+            // skip it (new_node_ids keeps the saved-index \u2192 node mapping intact
+            // with -1 so link/probe/group restoration stays in step).
+            try {
+                std::string type = cj.value("type", "");
+                auto &params = cj["params"];
+
+                const auto *desc = ComponentTypeRegistry::instance().findByProjectType(type);
+                if (!desc) {
+                    LOG_WARN("Unknown component type in project file: %s", type.c_str());
+                    new_node_ids.push_back(-1);
+                    continue;
+                }
+                IComponentEngine *comp = desc->create(m_components, m_graph, m_next_component_id++);
+                // S1: resolve S-param paths against the project file's
+                // directory and neutralize any path that escapes it (the
+                // engine's deserialize() only sees the raw params JSON and
+                // cannot know the project dir).
+                resolveSparamParams(params, project_dir);
+                comp->deserialize(params);
+                if (desc->type == "pfb") {
+                    // Restore IQ plot + PFB grid widgets for this PFB
+                    m_pfb_views.addFor(*static_cast<PFBChannelizerEngine *>(comp), m_state);
+                }
+
+                new_node_ids.push_back(comp ? comp->graphNodeId() : -1);
+
+                // Restore position
+                if (comp && cj.contains("pos")) {
+                    ImNodes::EditorContextSet(m_graph_widget.context());
+                    ImNodes::SetNodeEditorSpacePos(
+                        comp->graphNodeId(),
+                        ImVec2(cj["pos"].value("x", 0.0f), cj["pos"].value("y", 0.0f)));
+                }
+
+                // Restore library part number
+                if (comp && cj.contains("part_number"))
+                    m_graph.setNodePartNumber(comp->graphNodeId(),
+                                              cj["part_number"].get<std::string>());
+            } catch (const std::exception &e) {
+                LOG_ERROR("Skipping malformed component %zu in project file %s: %s", current_index,
+                          path.c_str(), e.what());
+                new_node_ids.push_back(-1);
             }
         }
-        if (member_ids.size() >= 2) {
-            int gid = m_graph.addGroup(name, member_ids);
-            bool collapsed = gj.value("collapsed", true);
-            if (gid >= 0)
-                m_graph.setGroupCollapsed(gid, collapsed);
+        // After restoring all positions, inform the widget so subsequent
+        // syncNodesFromEngine calls (e.g. from saveProject) don't reset them.
+        m_graph_widget.markNodesRegistered();
+
+        // Restore links (saved as component-index + port pairs)
+        auto &saved_links = root["links"];
+        for (const auto &lj : saved_links) {
+            int from_idx = lj.value("from", -1);
+            int to_idx = lj.value("to", -1);
+            int from_port = lj.value("from_port", 0);
+            int to_port = lj.value("to_port", 0);
+            if (from_idx < 0 || to_idx < 0 ||
+                static_cast<size_t>(from_idx) >= new_node_ids.size() ||
+                static_cast<size_t>(to_idx) >= new_node_ids.size())
+                continue;
+
+            int from_node = new_node_ids[from_idx];
+            int to_node = new_node_ids[to_idx];
+            if (from_node < 0 || to_node < 0)
+                continue;
+
+            auto *from_comp = m_components.find(from_node);
+            auto *to_comp = m_components.find(to_node);
+            if (!from_comp || !to_comp)
+                continue;
+
+            int start_pin = from_comp->outputPinId(from_port);
+            int end_pin = to_comp->inputPinId(to_port);
+            if (start_pin >= 0 && end_pin >= 0)
+                m_graph.addLink(start_pin, end_pin);
         }
-    }
 
-    // Restore window state
-    auto &ws = root["window_state"];
-    if (!ws.is_null()) {
-        m_show_log = ws.value("log", true);
-        m_show_spectrum = ws.value("spectrum_analyzer", true);
-        m_show_properties = ws.value("properties", true);
-        m_show_node_editor = ws.value("node_editor", true);
-    }
+        // Restore probes
+        auto &saved_probes = root["probe_pins"];
+        for (const auto &pj : saved_probes) {
+            int comp_idx = pj.value("comp", -1);
+            int port = pj.value("port", 0);
+            bool is_output = pj.value("is_output", true);
+            if (comp_idx < 0 || static_cast<size_t>(comp_idx) >= m_components.size())
+                continue;
+            auto *comp = m_components.all()[comp_idx];
+            int pin = is_output ? comp->outputPinId(port) : comp->inputPinId(port);
+            if (pin >= 0)
+                m_graph.addProbePin(pin);
+        }
 
-    // Restore graph state counters
-    auto &gs = root["graph_state"];
-    if (!gs.is_null()) {
-        m_next_component_id = gs.value("next_component_id", m_next_component_id);
+        // Restore groups
+        auto &saved_groups = root["groups"];
+        for (const auto &gj : saved_groups) {
+            std::string name = gj.value("name", "Group");
+            std::vector<int> member_ids;
+            for (const auto &mj : gj["member_components"]) {
+                int comp_idx = mj.get<int>();
+                if (comp_idx >= 0 && static_cast<size_t>(comp_idx) < new_node_ids.size() &&
+                    new_node_ids[comp_idx] >= 0) {
+                    member_ids.push_back(new_node_ids[comp_idx]);
+                }
+            }
+            if (member_ids.size() >= 2) {
+                int gid = m_graph.addGroup(name, member_ids);
+                bool collapsed = gj.value("collapsed", true);
+                if (gid >= 0)
+                    m_graph.setGroupCollapsed(gid, collapsed);
+            }
+        }
+
+        // Restore window state
+        auto &ws = root["window_state"];
+        if (!ws.is_null()) {
+            m_show_log = ws.value("log", true);
+            m_show_spectrum = ws.value("spectrum_analyzer", true);
+            m_show_properties = ws.value("properties", true);
+            m_show_node_editor = ws.value("node_editor", true);
+        }
+
+        // Restore graph state counters
+        auto &gs = root["graph_state"];
+        if (!gs.is_null()) {
+            m_next_component_id = gs.value("next_component_id", m_next_component_id);
+        }
+    } catch (const nlohmann::json::exception &e) {
+        LOG_ERROR("Malformed project file %s: %s", path.c_str(), e.what());
+        return false;
     }
 
     LOG_INFO("Loaded project from %s", path.c_str());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,10 +30,9 @@ if(WIN32)
     list(APPEND TEST_SOURCES test_session_state.cpp)
 endif()
 
-add_executable(tests ${TEST_SOURCES})
-
-target_link_libraries(tests PRIVATE
-    Catch2::Catch2WithMain
+# Pure-DSP engine libraries shared by the main `tests` binary and the
+# standalone test_signal_domain executable.
+set(TEST_ENGINE_LIBS
     common
     simulator::signal_generator_engine
     simulator::amplifier_engine
@@ -49,6 +48,13 @@ target_link_libraries(tests PRIVATE
     simulator::attenuator_engine
     simulator::combiner_engine
     simulator::pfb_channelizer_engine
+)
+
+add_executable(tests ${TEST_SOURCES})
+
+target_link_libraries(tests PRIVATE
+    Catch2::Catch2WithMain
+    ${TEST_ENGINE_LIBS}
     simulator::iq_plot_widget
     simulator::app
     simulator::layout
@@ -58,98 +64,77 @@ target_compile_definitions(tests PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}
 include(CTest)
 include(Catch)
 catch_discover_tests(tests)
-add_executable(test_attenuator test_attenuator.cpp)
-target_link_libraries(test_attenuator PRIVATE
-    simulator::attenuator_engine
-    simulator::node_graph_engine
-    Catch2::Catch2WithMain
-)
-target_compile_definitions(test_attenuator PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-add_test(NAME test_attenuator COMMAND test_attenuator WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-add_executable(test_combiner test_combiner.cpp)
-target_link_libraries(test_combiner PRIVATE
-    simulator::combiner_engine
-    simulator::node_graph_engine
-    Catch2::Catch2WithMain
+# Registers a standalone test executable with the standard per-test boilerplate
+# (Catch2 link, PROJECT_SOURCE_DIR compile definition, CTest registration).
+function(add_standalone_test NAME)
+    cmake_parse_arguments(ARG "" "" "SOURCES;LIBS" ${ARGN})
+    add_executable(${NAME} ${ARG_SOURCES})
+    target_link_libraries(${NAME} PRIVATE ${ARG_LIBS} Catch2::Catch2WithMain)
+    target_compile_definitions(${NAME} PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+    add_test(NAME ${NAME} COMMAND ${NAME} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endfunction()
+
+add_standalone_test(test_attenuator
+    SOURCES test_attenuator.cpp
+    LIBS simulator::attenuator_engine simulator::node_graph_engine
 )
-target_compile_definitions(test_combiner PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-add_test(NAME test_combiner COMMAND test_combiner WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_standalone_test(test_combiner
+    SOURCES test_combiner.cpp
+    LIBS simulator::combiner_engine simulator::node_graph_engine
+)
 
 # Standalone executable for all new tests added by the component-library authoring UI
 # plan (docs/superpowers/plans/2026-07-28-component-library-authoring-ui.md). Kept out
 # of the main `tests` binary because this MinGW-w64 toolchain silently drops any
-# TEST_CASE registered beyond the ~217 already linked into tests.exe (confirmed via a
-# from-scratch clean rebuild).
-add_executable(test_component_authoring test_component_authoring.cpp)
-target_link_libraries(test_component_authoring PRIVATE
-    simulator::app
-    Catch2::Catch2WithMain
+# TEST_CASE registered beyond a ceiling in tests.exe (verified 2026-08-09: 223
+# registered of ~460+ in source; earlier docs said ~217). The release.yml Windows
+# job guards this floor with `tests.exe --list-tests` count >= 223.
+add_standalone_test(test_component_authoring
+    SOURCES test_component_authoring.cpp
+    LIBS simulator::app
 )
-target_compile_definitions(test_component_authoring PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-add_test(NAME test_component_authoring COMMAND test_component_authoring WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 # Standalone for the same reason as test_component_authoring: TEST_CASEs appended
 # to the main `tests` binary are silently dropped by the MinGW-w64 toolchain, and
 # these must actually run on every CI platform (TutorialState is cross-platform,
 # unlike SessionState).
-add_executable(test_tutorial_state test_tutorial_state.cpp)
-target_link_libraries(test_tutorial_state PRIVATE
-    simulator::tutorial
-    Catch2::Catch2WithMain
+add_standalone_test(test_tutorial_state
+    SOURCES test_tutorial_state.cpp
+    LIBS simulator::tutorial
 )
-target_compile_definitions(test_tutorial_state PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-add_test(NAME test_tutorial_state COMMAND test_tutorial_state WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-add_executable(test_extensions test_extensions.cpp)
-target_link_libraries(test_extensions PRIVATE
-    simulator::app
-    Catch2::Catch2WithMain
+add_standalone_test(test_extensions
+    SOURCES test_extensions.cpp
+    LIBS simulator::app
 )
-target_compile_definitions(test_extensions PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-add_test(NAME test_extensions COMMAND test_extensions WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-add_executable(test_issue37_pfb_input_removal test_issue37_pfb_input_removal.cpp)
-target_link_libraries(test_issue37_pfb_input_removal PRIVATE
-    simulator::app
-    Catch2::Catch2WithMain
+add_standalone_test(test_issue37_pfb_input_removal
+    SOURCES test_issue37_pfb_input_removal.cpp
+    LIBS simulator::app
 )
-target_compile_definitions(test_issue37_pfb_input_removal PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-add_test(NAME test_issue37_pfb_input_removal COMMAND test_issue37_pfb_input_removal WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-add_executable(test_issue42_multi_output test_issue42_multi_output.cpp)
-target_link_libraries(test_issue42_multi_output PRIVATE
-    simulator::app
-    Catch2::Catch2WithMain
+add_standalone_test(test_issue42_multi_output
+    SOURCES test_issue42_multi_output.cpp
+    LIBS simulator::app
 )
-target_compile_definitions(test_issue42_multi_output PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-add_test(NAME test_issue42_multi_output COMMAND test_issue42_multi_output WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-add_executable(test_component_dispatch test_component_dispatch.cpp)
-target_link_libraries(test_component_dispatch PRIVATE
-    simulator::app
-    Catch2::Catch2WithMain
+add_standalone_test(test_component_dispatch
+    SOURCES test_component_dispatch.cpp
+    LIBS simulator::app
 )
-target_compile_definitions(test_component_dispatch PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-add_test(NAME test_component_dispatch COMMAND test_component_dispatch WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-add_executable(test_signal_domain test_signal_domain.cpp)
-target_link_libraries(test_signal_domain PRIVATE
-    common
-    simulator::signal_generator_engine
-    simulator::amplifier_engine
-    simulator::attenuator_engine
-    simulator::node_graph_engine
-    simulator::combiner_engine
-    simulator::equalizer_engine
-    simulator::ideal_filter_engine
-    simulator::coax_cable_engine
-    simulator::splitter_engine
-    simulator::mixer_engine
-    simulator::pfb_channelizer_engine
-    simulator::touchstone_parser
-    simulator::adc_engine
-    simulator::spectrum_analyzer_engine
-    Catch2::Catch2WithMain
+
+add_standalone_test(test_signal_domain
+    SOURCES test_signal_domain.cpp
+    LIBS ${TEST_ENGINE_LIBS}
 )
-target_compile_definitions(test_signal_domain PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-add_test(NAME test_signal_domain COMMAND test_signal_domain WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+# Standalone for the S1/S2 security-fix tests (S-param path containment at the
+# project-file and library boundaries + touchstone parser size/point guards).
+# Kept out of the main `tests` binary for the same MinGW-w64 registration
+# ceiling reason as test_component_authoring above.
+add_standalone_test(test_path_containment
+    SOURCES test_path_containment.cpp
+    LIBS simulator::app simulator::touchstone_parser
+)

--- a/tests/test_path_containment.cpp
+++ b/tests/test_path_containment.cpp
@@ -1,0 +1,286 @@
+// Standalone Catch2 executable for the S1/S2 security fixes from the
+// 2026-08-09 codebase review:
+//   S1 — S-param file path containment (project-file boundary in
+//        ProjectSerializer::load()/save(), library boundary in
+//        ComponentLibrary::instantiate())
+//   S2 — touchstone parser file-size guard + in-loop frequency-point cap
+//
+// Built as its own executable rather than appended to the main `tests` binary
+// because this MinGW-w64 toolchain silently drops any TEST_CASE registered
+// beyond the ceiling in tests.exe (see the comment above test_component_authoring
+// in tests/CMakeLists.txt).
+#include "amplifier_engine.h"
+#include "app.h"
+#include "component_library.h"
+#include "component_registry.h"
+#include "imgui.h"
+#include "imnodes.h"
+#include "implot.h"
+#include "node_graph_engine.h"
+#include "touchstone_parser.h"
+#include "view_manager.h"
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace {
+
+struct ImGuiFixture {
+    ImGuiFixture() {
+        ImGui::CreateContext();
+        ImPlot::CreateContext();
+        ImNodes::CreateContext();
+    }
+    ~ImGuiFixture() {
+        ImNodes::DestroyContext();
+        ImPlot::DestroyContext();
+        ImGui::DestroyContext();
+    }
+};
+
+std::filesystem::path scratchDir(const std::string &name) {
+    auto base = std::filesystem::temp_directory_path() / name;
+    std::filesystem::remove_all(base);
+    std::filesystem::create_directories(base);
+    return base;
+}
+
+// Minimal valid 2-port Touchstone file (freq + S11, S21, S12, S22 in MA).
+const char *kMinimalS2p = "# GHz S MA R 50\n"
+                          "1.0 0.5 0.0 2.0 90.0 0.1 180.0 0.3 -45.0\n";
+
+void writeS2p(const std::filesystem::path &path) {
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream ofs(path);
+    ofs << kMinimalS2p;
+}
+
+nlohmann::json amplifierComponent(const std::string &sparam_filepath) {
+    nlohmann::json cj;
+    cj["type"] = "Amplifier"; // .rfsim project_type key
+    cj["params"]["gain_dB"] = 20.0;
+    cj["params"]["nf_dB"] = 1.0;
+    cj["params"]["sparam_mode"] = true;
+    cj["params"]["sparam_filepath"] = sparam_filepath;
+    return cj;
+}
+
+void writeProject(const std::filesystem::path &path, const nlohmann::json &components) {
+    nlohmann::json root;
+    root["version"] = 1;
+    root["components"] = components;
+    std::ofstream ofs(path);
+    ofs << root.dump(2);
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// S1 — project-file boundary: untrusted S-param paths must not read files
+// outside the project directory. Absolute paths outside the project dir and
+// '..' traversal are neutralized (path cleared, nothing loaded); a contained
+// relative path resolves against the project dir (not the CWD) and loads.
+// ---------------------------------------------------------------------------
+TEST_CASE_METHOD(ImGuiFixture, "Project load neutralizes S-param paths outside the project dir",
+                 "[containment][project]") {
+    auto base = scratchDir("containment_project_test");
+    const auto project_path = base / "proj.rfsim";
+    const auto decoy = base.parent_path() / "containment_project_decoy.s2p";
+    writeS2p(decoy); // valid file OUTSIDE the project dir
+    writeS2p(base / "data/good.s2p");
+
+    nlohmann::json comps = nlohmann::json::array();
+    comps.push_back(amplifierComponent(decoy.string()));     // absolute, outside project dir
+    comps.push_back(amplifierComponent("../../escape.s2p")); // '..' traversal
+    comps.push_back(amplifierComponent("data/good.s2p"));    // contained relative path
+    writeProject(project_path, comps);
+
+    {
+        RfSimulatorApp app;
+        app.loadProject(project_path.string());
+        REQUIRE(app.componentCount() == 3);
+
+        auto amps = app.testComponents().byType<AmplifierEngine>();
+        REQUIRE(amps.size() == 3);
+
+        // Absolute path outside the project dir: neutralized, nothing loaded.
+        CHECK_FALSE(amps[0]->sparamLoaded());
+        CHECK(amps[0]->sparamFilepath().empty());
+        CHECK_FALSE(amps[0]->sparamMode());
+
+        // '..' traversal: neutralized, nothing loaded.
+        CHECK_FALSE(amps[1]->sparamLoaded());
+        CHECK(amps[1]->sparamFilepath().empty());
+        CHECK_FALSE(amps[1]->sparamMode());
+
+        // Contained relative path: resolved against the project dir and loaded
+        // (the CWD has no data/good.s2p, so this only works if the resolution
+        // uses the project dir).
+        CHECK(amps[2]->sparamLoaded());
+        const auto expected = std::filesystem::weakly_canonical(base / "data/good.s2p").string();
+        CHECK(amps[2]->sparamFilepath() == expected);
+    }
+    std::filesystem::remove_all(base);
+    std::filesystem::remove(decoy);
+}
+
+TEST_CASE_METHOD(ImGuiFixture, "Project save persists in-project S-param paths as relative",
+                 "[containment][project]") {
+    auto base = scratchDir("containment_roundtrip_test");
+    const auto project_path = base / "proj.rfsim";
+    writeS2p(base / "data/good.s2p");
+
+    // Absolute path that stays inside the project dir is honored on load...
+    nlohmann::json comps = nlohmann::json::array();
+    comps.push_back(
+        amplifierComponent(std::filesystem::weakly_canonical(base / "data/good.s2p").string()));
+    writeProject(project_path, comps);
+
+    {
+        RfSimulatorApp app;
+        app.loadProject(project_path.string());
+        auto amps = app.testComponents().byType<AmplifierEngine>();
+        REQUIRE(amps.size() == 1);
+        REQUIRE(amps[0]->sparamLoaded());
+
+        // ...but re-saving re-writes it relative to the project dir, so the
+        // file stays portable between machines.
+        app.saveProject(project_path.string());
+    }
+
+    nlohmann::json saved;
+    {
+        std::ifstream ifs(project_path);
+        ifs >> saved;
+    }
+    REQUIRE(saved["components"][0]["params"]["sparam_filepath"] == "data/good.s2p");
+
+    // The relative path round-trips: reload from the same file still loads.
+    {
+        RfSimulatorApp app;
+        app.loadProject(project_path.string());
+        auto amps = app.testComponents().byType<AmplifierEngine>();
+        REQUIRE(amps.size() == 1);
+        REQUIRE(amps[0]->sparamLoaded());
+    }
+    std::filesystem::remove_all(base);
+}
+
+// ---------------------------------------------------------------------------
+// S1 — library boundary: data_files entries must stay within the library JSON
+// file's directory; absolute and '..' entries are skipped, not read.
+// ---------------------------------------------------------------------------
+TEST_CASE("Library instantiate skips S-param data files outside the library dir",
+          "[containment][library]") {
+    auto base = scratchDir("containment_lib_test");
+    const auto json_path = base / "lib.json";
+    const auto decoy = base.parent_path() / "containment_lib_decoy.s2p";
+    writeS2p(decoy); // valid file OUTSIDE the library dir
+    writeS2p(base / "good.s2p");
+
+    nlohmann::json j;
+    j["schema_version"] = 2;
+    j["type"] = "amplifier";
+    j["part_number"] = "CONTAINMENT-LIB";
+    j["parameters"]["gain_dB"] = 20.0;
+    j["parameters"]["nf_dB"] = 1.0;
+    j["data_files"] = nlohmann::json::array();
+    j["data_files"].push_back({{"type", "s_parameters"}, {"path", "../containment_lib_decoy.s2p"}});
+    j["data_files"].push_back({{"type", "s_parameters"}, {"path", decoy.string()}});
+    j["data_files"].push_back({{"type", "s_parameters"}, {"path", "good.s2p"}});
+    {
+        std::ofstream ofs(json_path);
+        ofs << j.dump(2);
+    }
+
+    ComponentLibrary lib;
+    lib.loadFile(json_path.string());
+    auto defs = lib.all();
+    REQUIRE(defs.size() == 1);
+
+    NodeGraphEngine graph;
+    ViewManager view;
+    ComponentRegistry registry(graph, view);
+    auto *engine = lib.instantiate(*defs[0], 400, registry, graph);
+    REQUIRE(engine != nullptr);
+
+    auto *amp = dynamic_cast<AmplifierEngine *>(engine);
+    REQUIRE(amp != nullptr);
+    // The two rejected entries are skipped; only the contained one loads.
+    REQUIRE(amp->sparamLoaded());
+    CHECK(amp->sparamFilepath() == std::filesystem::weakly_canonical(base / "good.s2p").string());
+
+    std::filesystem::remove_all(base);
+    std::filesystem::remove(decoy);
+}
+
+TEST_CASE("Library instantiate rejects when every S-param data file escapes",
+          "[containment][library]") {
+    auto base = scratchDir("containment_lib_reject_test");
+    const auto json_path = base / "lib.json";
+    const auto decoy = base.parent_path() / "containment_lib_reject_decoy.s2p";
+    writeS2p(decoy); // valid file OUTSIDE the library dir
+
+    nlohmann::json j;
+    j["schema_version"] = 2;
+    j["type"] = "amplifier";
+    j["part_number"] = "CONTAINMENT-REJECT";
+    j["parameters"]["gain_dB"] = 20.0;
+    j["parameters"]["nf_dB"] = 1.0;
+    j["data_files"] = nlohmann::json::array();
+    j["data_files"].push_back({{"type", "s_parameters"}, {"path", decoy.string()}});
+    j["data_files"].push_back({{"type", "s_parameters"}, {"path", "../escape.s2p"}});
+    {
+        std::ofstream ofs(json_path);
+        ofs << j.dump(2);
+    }
+
+    ComponentLibrary lib;
+    lib.loadFile(json_path.string());
+    auto defs = lib.all();
+    REQUIRE(defs.size() == 1);
+
+    NodeGraphEngine graph;
+    ViewManager view;
+    ComponentRegistry registry(graph, view);
+    auto *engine = lib.instantiate(*defs[0], 401, registry, graph);
+    REQUIRE(engine != nullptr);
+
+    auto *amp = dynamic_cast<AmplifierEngine *>(engine);
+    REQUIRE(amp != nullptr);
+    // Nothing was loaded: the engine falls back to single-point params.
+    CHECK_FALSE(amp->sparamLoaded());
+    CHECK_FALSE(amp->sparamMode());
+    CHECK(amp->gain_dB() == Catch::Approx(20.0));
+
+    std::filesystem::remove_all(base);
+    std::filesystem::remove(decoy);
+}
+
+// ---------------------------------------------------------------------------
+// S2 — touchstone parser: a file larger than the 256 MiB guard is rejected
+// before its content is buffered. The same content parses fine at a small
+// size, proving the size guard (not the content) is what rejects it.
+// ---------------------------------------------------------------------------
+TEST_CASE("TouchstoneParser rejects oversized files before reading", "[containment][touchstone]") {
+    const auto path = std::filesystem::temp_directory_path() / "containment_oversized.s2p";
+    writeS2p(path);
+
+    // Content is valid at a normal size...
+    auto before = TouchstoneParser::parse(path.string());
+    REQUIRE(before.has_value());
+
+    // ...extend the file past the 256 MiB parse cap. resize_file extends
+    // without writing data (cheap on NTFS; zero-fill on other filesystems).
+    std::error_code ec;
+    std::filesystem::resize_file(path, 300LL * 1024 * 1024, ec);
+    REQUIRE_FALSE(ec);
+
+    auto after = TouchstoneParser::parse(path.string());
+    REQUIRE_FALSE(after.has_value());
+
+    std::filesystem::remove(path);
+}

--- a/tests/test_project_file.cpp
+++ b/tests/test_project_file.cpp
@@ -170,6 +170,72 @@ TEST_CASE_METHOD(ImGuiFixture, "Load invalid JSON does not crash", "[project_fil
 }
 
 // ---------------------------------------------------------------------------
+// 6b — Loading valid JSON with the wrong shape must not crash: either it loads
+//      as an empty project or it fails gracefully, leaving a usable app.
+// ---------------------------------------------------------------------------
+TEST_CASE_METHOD(ImGuiFixture, "Load empty object JSON is a valid empty project",
+                 "[project_file]") {
+    auto path = tempPath("_empty");
+    std::remove(path.c_str());
+    {
+        std::ofstream out(path);
+        out << "{}";
+    }
+    {
+        RfSimulatorApp app;
+        app.loadProject(path); // must not crash (regression: shape access was unguarded)
+        REQUIRE(app.componentCount() == 0); // {} is a valid (empty) project
+    }
+    std::remove(path.c_str());
+}
+
+TEST_CASE_METHOD(ImGuiFixture, "Load wrong-shape JSON fails gracefully, no crash",
+                 "[project_file]") {
+    SECTION("components is not an array") {
+        auto path = tempPath("_comp5");
+        std::remove(path.c_str());
+        {
+            std::ofstream out(path);
+            out << R"({"components": 5})";
+        }
+        {
+            RfSimulatorApp app;
+            app.loadProject(path); // must not crash; load fails, project cleared
+            REQUIRE(app.componentCount() == 0);
+        }
+        std::remove(path.c_str());
+    }
+    SECTION("component entry wrong-typed (type is a number)") {
+        auto path = tempPath("_typed");
+        std::remove(path.c_str());
+        {
+            std::ofstream out(path);
+            out << R"({"components": [{"type": 42}]})";
+        }
+        {
+            RfSimulatorApp app;
+            app.loadProject(path);              // must not crash; bad component is skipped
+            REQUIRE(app.componentCount() == 0); // skipped, nothing else to load
+        }
+        std::remove(path.c_str());
+    }
+    SECTION("window_state wrong-typed") {
+        auto path = tempPath("_ws");
+        std::remove(path.c_str());
+        {
+            std::ofstream out(path);
+            out << R"({"window_state": 5})";
+        }
+        {
+            RfSimulatorApp app;
+            app.loadProject(path); // must not crash; load fails, project cleared
+            REQUIRE(app.componentCount() == 0);
+        }
+        std::remove(path.c_str());
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 7 — Add components with custom parameter values, save, reload, verify that
 //     every parameter survived the round-trip.
 // ---------------------------------------------------------------------------
@@ -455,28 +521,34 @@ TEST_CASE_METHOD(ImGuiFixture, "Round-trip: S-param mode survives save/load (iss
     auto path = tempPath();
     std::remove(path.c_str());
     const std::string s2p = sparamFixturePath();
+    // S1 containment (2026-08-09): S-param paths in project files resolve
+    // against the project file's directory and must stay inside it, so the
+    // fixture is staged next to the project file and referenced by its
+    // relative name (the project file itself lives in the CWD).
+    const std::string local_s2p = tempPath("_fixture.s2p");
+    std::filesystem::copy_file(s2p, local_s2p, std::filesystem::copy_options::overwrite_existing);
     {
         RfSimulatorApp app;
         app.newProject();
 
         auto &amp = app.testComponents().add<AmplifierEngine>(10001, app.testGraphEngine());
-        amp.setSParamFilepath(s2p);
+        amp.setSParamFilepath(local_s2p);
         REQUIRE(amp.sparamLoaded());
 
         auto &flt = app.testComponents().add<IdealFilterEngine>(10002, app.testGraphEngine());
-        flt.setSParamFilepath(s2p);
+        flt.setSParamFilepath(local_s2p);
         REQUIRE(flt.sparamLoaded());
 
         auto &eq = app.testComponents().add<EqualizerEngine>(10003, app.testGraphEngine());
-        eq.setSParamFilepath(s2p);
+        eq.setSParamFilepath(local_s2p);
         REQUIRE(eq.sparamLoaded());
 
         auto &atten = app.testComponents().add<AttenuatorEngine>(10004, app.testGraphEngine());
-        atten.setSParamFile(s2p);
+        atten.setSParamFile(local_s2p);
         REQUIRE(atten.sParamMode());
 
         auto &comb = app.testComponents().add<CombinerEngine>(10005, app.testGraphEngine());
-        comb.setSParamFile(s2p);
+        comb.setSParamFile(local_s2p);
         REQUIRE(comb.sParamMode());
 
         REQUIRE(app.componentCount() == 5);
@@ -511,4 +583,5 @@ TEST_CASE_METHOD(ImGuiFixture, "Round-trip: S-param mode survives save/load (iss
         CHECK(combs[0]->sParamMode() == true);
     }
     std::remove(path.c_str());
+    std::filesystem::remove(local_s2p);
 }

--- a/touchstone/src/touchstone_parser.cpp
+++ b/touchstone/src/touchstone_parser.cpp
@@ -79,15 +79,66 @@ std::complex<double> TouchstoneParser::parsePair(double a, double b, TouchstoneD
 }
 
 std::optional<TouchstoneData> TouchstoneParser::parse(const std::string &filepath) {
-    std::ifstream file(filepath);
+    // R2: Cap the file size before reading anything. A legitimate Touchstone
+    // dataset at the frequency-point cap below (10M points x 9 values/point x
+    // ~10 bytes/value) stays far under 256 MiB, so anything larger cannot
+    // parse successfully and would otherwise be buffered whole into
+    // raw_values (up to ~960 MB at the point cap). Binary mode keeps tellg()
+    // exact; the read loop below already strips '\r' from line endings, so
+    // CRLF files parse identically to text mode.
+    constexpr std::streamoff MAX_FILE_BYTES = 256LL * 1024 * 1024; // 256 MiB
+    std::ifstream file(filepath, std::ios::binary);
     if (!file.is_open())
         return std::nullopt;
+
+    file.seekg(0, std::ios::end);
+    const std::streamoff file_size = file.tellg();
+    if (file_size < 0 || file_size > MAX_FILE_BYTES)
+        return std::nullopt;
+    file.seekg(0, std::ios::beg);
 
     TouchstoneData data;
     bool option_line_found = false;
     bool has_version_keyword = false;
     std::string line;
     std::vector<double> raw_values; // all numeric values from data lines
+
+    // Infer port count from file extension if not explicitly known
+    // .s1p -> 1 port, .s2p -> 2 ports, etc. (Hoisted ahead of the read loop
+    // so the in-loop frequency-point cap below knows the values per point.)
+    size_t dot = filepath.rfind('.');
+    if (dot != std::string::npos && dot + 2 < filepath.size() && filepath[dot + 1] == 's') {
+        char port_char = filepath[dot + 2];
+        if (port_char >= '1' && port_char <= '9') {
+            data.num_ports = port_char - '0';
+        }
+    }
+    if (data.num_ports == 0) {
+        // Try to infer from data density
+        // v1.0 2-port: 9 values per point (freq + 4 pairs)
+        // v1.0 1-port: 3 values per point (freq + 1 pair)
+        // We can't reliably infer without hints, so default to 2 for .s2p files
+        data.num_ports = 2;
+    }
+
+    int pairs_per_freq = 0;
+    if (data.num_ports == 1) {
+        pairs_per_freq = 1;
+    } else if (data.num_ports == 2) {
+        pairs_per_freq = 4; // N11, N21, N12, N22
+    } else {
+        pairs_per_freq = data.num_ports * data.num_ports;
+    }
+    int values_per_freq = 1 + pairs_per_freq * 2;
+
+    // R2: Upper bound on frequency points to prevent OOM. Enforced DURING the
+    // read loop: once more than MAX_FREQ_POINTS * values_per_freq raw values
+    // are buffered, the point count provably exceeds the cap, so bail out
+    // before allocating any more. (The post-loop check below is retained as
+    // defense-in-depth.)
+    constexpr size_t MAX_FREQ_POINTS = 10000000;
+    const size_t max_raw_values =
+        static_cast<size_t>(MAX_FREQ_POINTS) * static_cast<size_t>(values_per_freq);
 
     while (std::getline(file, line)) {
         // Normalize line endings (CR, LF, CRLF)
@@ -131,37 +182,14 @@ std::optional<TouchstoneData> TouchstoneParser::parse(const std::string &filepat
         while (iss >> val) {
             raw_values.push_back(val);
         }
+
+        // R2 in-loop: bail out as soon as the cap is provably exceeded.
+        if (raw_values.size() > max_raw_values)
+            return std::nullopt;
     }
 
     if (!option_line_found)
         return std::nullopt;
-
-    // Infer port count from file extension if not explicitly known
-    // .s1p -> 1 port, .s2p -> 2 ports, etc.
-    size_t dot = filepath.rfind('.');
-    if (dot != std::string::npos && dot + 2 < filepath.size() && filepath[dot + 1] == 's') {
-        char port_char = filepath[dot + 2];
-        if (port_char >= '1' && port_char <= '9') {
-            data.num_ports = port_char - '0';
-        }
-    }
-    if (data.num_ports == 0) {
-        // Try to infer from data density
-        // v1.0 2-port: 9 values per point (freq + 4 pairs)
-        // v1.0 1-port: 3 values per point (freq + 1 pair)
-        // We can't reliably infer without hints, so default to 2 for .s2p files
-        data.num_ports = 2;
-    }
-
-    int pairs_per_freq = 0;
-    if (data.num_ports == 1) {
-        pairs_per_freq = 1;
-    } else if (data.num_ports == 2) {
-        pairs_per_freq = 4; // N11, N21, N12, N22
-    } else {
-        pairs_per_freq = data.num_ports * data.num_ports;
-    }
-    int values_per_freq = 1 + pairs_per_freq * 2;
 
     if (raw_values.size() % values_per_freq != 0) {
         // Mismatch: try to be lenient or return null
@@ -170,8 +198,8 @@ std::optional<TouchstoneData> TouchstoneParser::parse(const std::string &filepat
 
     size_t num_freq_points = raw_values.size() / values_per_freq;
 
-    // R2: Upper bound on frequency points to prevent OOM
-    constexpr size_t MAX_FREQ_POINTS = 10000000;
+    // R2: Defense-in-depth cap (the in-loop check above already bounds the
+    // buffer, but keep the explicit check for clarity and safety).
     if (num_freq_points > MAX_FREQ_POINTS)
         return std::nullopt;
 


### PR DESCRIPTION
## Summary

Crash/robustness fixes from a comprehensive codebase review (findings C1, B7, S1, S2).

- **Malformed project JSON crashes the app (C1).** `ProjectSerializer::load()` caught only JSON *parse* errors; wrong-shape-but-valid JSON (`{}`, `"components": 5`, wrong-typed params, non-object `window_state`) threw uncaught nlohmann exceptions and `std::terminate`d. Now: 64 MiB size cap before parse, root must be an object, the whole load body is guarded (`json::exception` → log + graceful failure), and each component `deserialize` is isolated so one bad component is skipped while the rest load. Same crash class fixed at the library boundary (`component_library` `loadFile` catches `type_error`; scan tolerates `filesystem_error`).
- **Coax preset OOB (B7).** `deserialize` clamped `preset_index`/`length_m`/`connectors_loss_dB` — previously an out-of-range index into `kCoaxCablePresets` from a corrupted project was UB.
- **S-param path containment (S1).** S-param paths in project files now resolve against the project file's directory and must stay inside it (`weakly_canonical` + prefix, mirroring the extension manifest parser). Absolute/escaping paths are neutralized with a warning. Library `data_files` entries get the same containment. Save re-relativizes in-project absolute paths so projects stay portable.
- **Touchstone OOM caps (S2).** Parser rejects > 256 MiB files before reading and enforces the 10M-point cap during the read loop instead of after buffering (~960 MB OOM window removed).

## Verification

- `tests.exe`: 218 test cases / 65534 assertions, all pass (216 baseline + 2 new wrong-shape JSON cases).
- New standalone `test_path_containment` exe: 5 cases / 29 assertions.
- Full build green (MinGW-w64, Debug, ninja).

## Notes for merging

- Contains a behavior change: absolute S-param paths **outside** the project dir are neutralized at load — keep `.s2p` data inside the project directory. Relative paths now resolve against the project dir (portable) instead of the process CWD.
- Expected conflict with `refactor/engine-unification` in `tests/test_project_file.cpp` (the #56 test's attenuator/combiner lines: this branch stages the fixture with the old API names, that branch renames the API). Merge this branch first; resolve by keeping `setSParamFilepath(local_s2p)` / `sparamMode()`.
