### PR TITLE
fix: DSP accuracy — nonlinear harmonic formulas, PFB K/beta cache, PFB severed-input, ideal-filter noise

### DIFF
--- a/common/component_engine_base.h
+++ b/common/component_engine_base.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "component_interface.h"
+#include "node_graph_engine.h"
+#include "signal_node.h"
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+// ComponentEngineBase — shared boilerplate for the graph-attached DSP engines.
+//
+// Owns the members and accessors that every engine repeats verbatim:
+//   - the component id and graph node id (id(), graphNodeId())
+//   - the owning NodeGraphEngine pointer plus the graph node created by the
+//     constructor via NodeGraphEngine::addNode (constructor shape: label +
+//     id, input/output pin counts)
+//   - the engine's SignalNode and the node() accessors
+//   - the dirty flag that forces recomputation on the next update()
+//   - the cached single-input (pointer, generation) pair with beginUpdate(),
+//     the standard single-input dirty-check prologue
+//
+// Subclasses still implement the IComponentEngine pure virtuals
+// (type_name(), hoverSummary(), update(), serialize(), deserialize()) and may
+// override inputPinId()/outputPinId() for multi-pin layouts.
+class ComponentEngineBase : public IComponentEngine {
+  public:
+    ComponentEngineBase(int id, NodeGraphEngine &graph, std::string_view label, int num_inputs,
+                        int num_outputs)
+        : m_id(id), m_graph(&graph) {
+        m_graph_node_id = graph.addNode(std::string(label) + " " + std::to_string(id), &m_node,
+                                        num_inputs, num_outputs);
+        m_node.inputs.resize(num_inputs);
+        m_node.outputs.resize(num_outputs);
+    }
+
+    int id() const override { return m_id; }
+    int graphNodeId() const override { return m_graph_node_id; }
+
+    int inputPinId() const override { return m_graph ? m_graph->inputPinId(m_graph_node_id) : -1; }
+    int outputPinId() const override {
+        return m_graph ? m_graph->outputPinId(m_graph_node_id) : -1;
+    }
+
+    SignalNode &node() override { return m_node; }
+    const SignalNode &node() const override { return m_node; }
+
+  protected:
+    // Standard single-input dirty-check prologue. Returns true when update()
+    // must recompute (dirty flag set, or the input pointer/generation changed
+    // since the last update); on that path it clears the dirty flag and
+    // records the current input for the next comparison. Returns false when
+    // the input is unchanged and the engine is clean — callers return without
+    // recomputing.
+    bool beginUpdate(const Spectrum *in_ptr) {
+        if (!m_dirty && in_ptr == m_cached_input_ptr &&
+            (!in_ptr || in_ptr->generation == m_cached_input_generation))
+            return false;
+        m_dirty = false;
+        m_cached_input_ptr = in_ptr;
+        if (in_ptr)
+            m_cached_input_generation = in_ptr->generation;
+        return true;
+    }
+
+    int m_id;
+    int m_graph_node_id = -1;
+    NodeGraphEngine *m_graph = nullptr;
+    bool m_dirty = true;
+    const Spectrum *m_cached_input_ptr = nullptr;
+    uint64_t m_cached_input_generation = 0;
+    SignalNode m_node;
+};

--- a/common/nonlinear_model.h
+++ b/common/nonlinear_model.h
@@ -79,12 +79,14 @@ class NonlinearModel {
             double Pout_dBm = tone.power_dBm + 20.0 * std::log10(g_linear);
             double Vp1 = dbmToV(Pout_dBm);
 
-            double V_h2 = m_k1 * Vp1 / std::sqrt(2.0);
+            // H2: v_in^2 term -> RMS k1*A^2/(2*sqrt(2)) = k1*Vp1^2/sqrt(2), A = sqrt(2)*Vp1
+            double V_h2 = m_k1 * Vp1 * Vp1 / std::sqrt(2.0);
             double H2_dBm = vToDbm(V_h2);
             r.extra_tones.push_back({tone.freq_Hz * 2.0, H2_dBm, 0.0});
             total_distortion_mW += dbmToW(H2_dBm);
 
-            double V_h3 = m_k2 * Vp1 * Vp1 * Vp1 / 4.0;
+            // H3: v_in^3 term -> RMS k2*A^3/(4*sqrt(2)) = k2*Vp1^3/2, A = sqrt(2)*Vp1
+            double V_h3 = m_k2 * Vp1 * Vp1 * Vp1 / 2.0;
             double H3_dBm = vToDbm(V_h3);
             r.extra_tones.push_back({tone.freq_Hz * 3.0, H3_dBm, 0.0});
             total_distortion_mW += dbmToW(H3_dBm);

--- a/ideal_filter/include/ideal_filter_engine.h
+++ b/ideal_filter/include/ideal_filter_engine.h
@@ -1,21 +1,17 @@
 #pragma once
-#include "component_interface.h"
+#include "component_engine_base.h"
 #include "node_graph_engine.h"
 #include "s_parameter_data.h"
 #include "signal_node.h"
 
 enum class FilterType { LPF, HPF, BPF, BSF };
 
-class IdealFilterEngine : public IComponentEngine {
+class IdealFilterEngine : public ComponentEngineBase {
   public:
     IdealFilterEngine(int id, NodeGraphEngine &graph);
 
-    int id() const override { return m_id; }
-    int graphNodeId() const override { return m_graph_node_id; }
     std::string_view type_name() const override { return "filter"; }
     std::string hoverSummary() const override;
-    int inputPinId() const override;
-    int outputPinId() const override;
 
     void setFilterType(FilterType type) {
         m_type = type;
@@ -36,8 +32,6 @@ class IdealFilterEngine : public IComponentEngine {
     double fcLow_Hz() const { return m_fc_low_Hz; }
     double fcHigh_Hz() const { return m_fc_high_Hz; }
 
-    SignalNode &node() override { return m_node; }
-    const SignalNode &node() const override { return m_node; }
     void update(double dt) override;
     nlohmann::json serialize() const override;
     void deserialize(const nlohmann::json &) override;
@@ -54,16 +48,9 @@ class IdealFilterEngine : public IComponentEngine {
     const SParameterData &sparamData() const { return m_sparam_data; }
 
   private:
-    int m_id;
-    int m_graph_node_id = -1;
-    NodeGraphEngine *m_graph = nullptr;
-    SignalNode m_node;
-    bool m_dirty = true;
     FilterType m_type = FilterType::LPF;
     double m_fc_low_Hz = 100e6;
     double m_fc_high_Hz = 200e6;
-    const Spectrum *m_cached_input_ptr = nullptr;
-    uint64_t m_cached_input_generation = 0;
 
     bool isInPassband(double freq_Hz) const;
 

--- a/ideal_filter/src/ideal_filter_engine.cpp
+++ b/ideal_filter/src/ideal_filter_engine.cpp
@@ -3,11 +3,8 @@
 #include <nlohmann/json.hpp>
 #include <numbers>
 
-IdealFilterEngine::IdealFilterEngine(int id, NodeGraphEngine &graph) : m_id(id), m_graph(&graph) {
-    m_graph_node_id = graph.addNode("IdealFilter " + std::to_string(id), &m_node, 1, 1);
-    m_node.inputs.resize(1);
-    m_node.outputs.resize(1);
-}
+IdealFilterEngine::IdealFilterEngine(int id, NodeGraphEngine &graph)
+    : ComponentEngineBase(id, graph, "IdealFilter", 1, 1) {}
 
 void IdealFilterEngine::setSParamFilepath(const std::string &path) {
     m_sparam_filepath = path;
@@ -15,14 +12,6 @@ void IdealFilterEngine::setSParamFilepath(const std::string &path) {
     if (m_sparam_data.loaded())
         m_sparam_fwd_idx = 1 * m_sparam_data.numPorts() + 0;
     m_dirty = true;
-}
-
-int IdealFilterEngine::inputPinId() const {
-    return m_graph ? m_graph->inputPinId(m_graph_node_id) : -1;
-}
-
-int IdealFilterEngine::outputPinId() const {
-    return m_graph ? m_graph->outputPinId(m_graph_node_id) : -1;
 }
 
 bool IdealFilterEngine::isInPassband(double freq_Hz) const {
@@ -148,15 +137,22 @@ void IdealFilterEngine::update(double dt) {
     }
 
     out.noise_W.resize(N, 0.0);
-    for (size_t i = 0; i < N; ++i) {
-        if (isInPassband(out.frequencies[i]))
-            out.noise_W[i] = (in_ptr && i < in_ptr->noise_W.size()) ? in_ptr->noise_W[i] : 0.0;
-    }
-
     out.noise_added_W.assign(N, 0.0);
-    out.noise_total_W.resize(N);
-    for (size_t i = 0; i < N; ++i)
-        out.noise_total_W[i] = out.noise_W[i];
+    out.noise_total_W.resize(N, 0.0);
+    for (size_t i = 0; i < N; ++i) {
+        if (isInPassband(out.frequencies[i])) {
+            // Propagate the input's TOTAL noise (input noise + upstream added
+            // noise), exactly as the amplifier/attenuator engines do. Copying
+            // only in_ptr->noise_W silently drops upstream added noise: for a
+            // 0 dB ideal filter the in-band noise_total must equal the input's
+            // noise_total, otherwise the noise floor drops discontinuously
+            // across the filter when an amplifier sits upstream.
+            double nin =
+                (in_ptr && i < in_ptr->noise_total_W.size() ? in_ptr->noise_total_W[i] : 0.0);
+            out.noise_W[i] = nin;
+            out.noise_total_W[i] = nin;
+        }
+    }
 
     out.fs_Hz = in_ptr ? in_ptr->fs_Hz : 0.0;
     out.bumpGeneration();

--- a/pfb_channelizer/include/pfb_channelizer_engine.h
+++ b/pfb_channelizer/include/pfb_channelizer_engine.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "component_interface.h"
+#include "component_engine_base.h"
 #include "node_graph_engine.h"
 #include "signal_node.h"
 #include "spectrum.h"
@@ -25,16 +25,12 @@ struct PFBConfig {
     double beta = 8.0;
 };
 
-class PFBChannelizerEngine : public IComponentEngine {
+class PFBChannelizerEngine : public ComponentEngineBase {
   public:
     PFBChannelizerEngine(int id, NodeGraphEngine &graph);
 
-    int id() const override { return m_id; }
-    int graphNodeId() const override { return m_graph_node_id; }
     std::string_view type_name() const override { return "pfb"; }
     std::string hoverSummary() const override;
-    int inputPinId() const override;
-    int outputPinId() const override;
 
     void setChannelCount(int M);
     void setTapsPerBranch(int K);
@@ -68,23 +64,15 @@ class PFBChannelizerEngine : public IComponentEngine {
     void update(double dt) override;
     nlohmann::json serialize() const override;
     void deserialize(const nlohmann::json &) override;
-    SignalNode &node() override { return m_node; }
-    const SignalNode &node() const override { return m_node; }
 
   private:
-    int m_id;
-    int m_graph_node_id = -1;
-    NodeGraphEngine *m_graph = nullptr;
-    SignalNode m_node;
-
     PFBConfig m_cfg;
     int m_active_channel = 0;
     std::vector<PFBChannel> m_channels;
-    bool m_dirty = true;
-    const Spectrum *m_cached_input_ptr = nullptr;
-    uint64_t m_cached_input_generation = 0;
     std::vector<double> m_cached_freqs;
     double m_cached_Fs_Hz = 0;
+    int m_cached_K = 0;
+    double m_cached_beta = 0.0;
 
     void recomputeChannels(const std::vector<double> &freqs);
     double prototypeResponse(double offset_Hz) const;

--- a/pfb_channelizer/src/pfb_channelizer_engine.cpp
+++ b/pfb_channelizer/src/pfb_channelizer_engine.cpp
@@ -5,19 +5,7 @@
 #include <nlohmann/json.hpp>
 
 PFBChannelizerEngine::PFBChannelizerEngine(int id, NodeGraphEngine &graph)
-    : m_id(id), m_graph(&graph) {
-    m_graph_node_id = graph.addNode("PFB " + std::to_string(id), &m_node, 1, 2);
-    m_node.inputs.resize(1);
-    m_node.outputs.resize(2);
-}
-
-int PFBChannelizerEngine::inputPinId() const {
-    return m_graph ? m_graph->inputPinId(m_graph_node_id) : -1;
-}
-
-int PFBChannelizerEngine::outputPinId() const {
-    return m_graph ? m_graph->outputPinId(m_graph_node_id) : -1;
-}
+    : ComponentEngineBase(id, graph, "PFB", 1, 2) {}
 
 void PFBChannelizerEngine::setChannelCount(int M) {
     if (M < 2)
@@ -67,18 +55,12 @@ void PFBChannelizerEngine::setActiveChannel(int ch) {
 
 void PFBChannelizerEngine::update(double) {
     const Spectrum *in_ptr = m_node.inputs.empty() ? nullptr : m_node.inputs[0];
-    if (!m_dirty && in_ptr == m_cached_input_ptr &&
-        (!in_ptr || in_ptr->generation == m_cached_input_generation))
+    if (!beginUpdate(in_ptr))
         return;
-    m_dirty = false;
 
     if (in_ptr && in_ptr->fs_Hz > 0.0) {
         m_cfg.Fs_Hz = in_ptr->fs_Hz;
     }
-
-    m_cached_input_ptr = in_ptr;
-    if (in_ptr)
-        m_cached_input_generation = in_ptr->generation;
 
     auto &out = m_node.outputs[0];
 
@@ -87,17 +69,34 @@ void PFBChannelizerEngine::update(double) {
         out.tones.clear();
         out.noise_W.clear();
         out.noise_total_W.clear();
-        if (!out.frequencies.empty())
-            out.bumpGeneration();
+        out.bumpGeneration();
+        // Sever the full-band output too: it previously retained the last
+        // computed spectrum, so consumers caching on (pointer, generation)
+        // kept serving stale data after the input was cut.
+        auto &out_full = m_node.outputs[1];
+        out_full.frequencies.clear();
+        out_full.tones.clear();
+        out_full.noise_W.clear();
+        out_full.noise_total_W.clear();
+        out_full.noise_added_W.clear();
+        out_full.phase_deg.clear();
+        out_full.bumpGeneration();
         return;
     }
 
-    // Only recompute channels when frequency grid, Fs, or M changes
+    // Only recompute channels when frequency grid, Fs, M, K, or beta changes.
+    // bin_weights depend on prototypeResponse(), which is a function of both K
+    // and beta — a stale guard here would leave the noise path using filter
+    // weights from the last grid/Fs/M change while the tone path calls
+    // prototypeResponse() live, producing an internally inconsistent spectrum.
     if (in_ptr->frequencies != m_cached_freqs || m_cfg.Fs_Hz != m_cached_Fs_Hz ||
+        m_cfg.K != m_cached_K || m_cfg.beta != m_cached_beta ||
         m_channels.size() != static_cast<size_t>(m_cfg.M)) {
         recomputeChannels(in_ptr->frequencies);
         m_cached_freqs = in_ptr->frequencies;
         m_cached_Fs_Hz = m_cfg.Fs_Hz;
+        m_cached_K = m_cfg.K;
+        m_cached_beta = m_cfg.beta;
     }
 
     double bin_width =

--- a/tests/test_ideal_filter.cpp
+++ b/tests/test_ideal_filter.cpp
@@ -203,3 +203,38 @@ TEST_CASE("IdealFilter BSF passes noise outside stopband, blocks inside", "[filt
             REQUIRE(out.noise_total_W[i] == Approx(0.0).epsilon(1e-30));
     }
 }
+
+TEST_CASE("IdealFilter preserves upstream added noise in passband", "[filter]") {
+    NodeGraphEngine graph;
+    IdealFilterEngine filt(0, graph);
+    filt.setFilterType(FilterType::LPF);
+    filt.setCutoff_Hz(300e6);
+
+    // Drive from a synthetic spectrum whose noise_added_W is nonzero (e.g. an
+    // amplifier upstream). The generator used by the older noise tests has
+    // noise_added_W == 0, which is why dropping the added component was
+    // invisible. For a 0 dB ideal filter the in-band noise_total must equal the
+    // input's noise_total (input noise + upstream added noise).
+    Spectrum in;
+    in.frequencies.resize(401);
+    for (int i = 0; i < 401; ++i)
+        in.frequencies[i] = -200e6 + i * 1e6;
+    in.noise_W.assign(401, 1e-20);
+    in.noise_added_W.assign(401, 5e-21);
+    in.noise_total_W.assign(401, 1.5e-20);
+
+    filt.node().inputs[0] = &in;
+    filt.update(0.0);
+
+    const auto &out = filt.node().outputs[0];
+    REQUIRE(out.noise_total_W.size() == in.noise_total_W.size());
+    for (size_t i = 0; i < out.noise_total_W.size(); ++i) {
+        if (out.frequencies[i] <= 300e6)
+            REQUIRE(out.noise_total_W[i] == Approx(in.noise_total_W[i]).epsilon(1e-30));
+        else
+            REQUIRE(out.noise_total_W[i] == Approx(0.0).epsilon(1e-30));
+    }
+    // The ideal filter adds no noise of its own
+    for (double v : out.noise_added_W)
+        REQUIRE(v == Approx(0.0).epsilon(1e-30));
+}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -736,11 +736,23 @@ TEST_CASE("Amplifier generates 2nd and 3rd harmonics", "[amplifier][nonlinear]")
     REQUIRE(out.tones[0].freq_Hz == 100e6);
     REQUIRE(out.tones[0].power_dBm == Approx(-20.0).epsilon(0.001));
 
+    // Expected harmonics from the corrected formulas (see nonlinear_model.h):
+    //   H2 (RMS) = k1 * Vp1^2 / sqrt(2)   (v_in^2 term: peak k1*A^2/2 at 2w, A = sqrt(2)*Vp1)
+    //   H3 (RMS) = k2 * Vp1^3 / 2         (v_in^3 term: peak k2*A^3/4 at 3w, A = sqrt(2)*Vp1)
+    // with k1 = 1/V_oip2, k2 = 4/(3*V_oip3^2) and Vp1 the output-referred RMS voltage.
+    const double Vp1 = std::sqrt(std::pow(10.0, -20.0 / 10.0) * 0.001 * 50.0);
+    const double V_oip2 = std::sqrt(std::pow(10.0, 40.0 / 10.0) * 0.001 * 50.0);
+    const double V_oip3 = std::sqrt(std::pow(10.0, 30.0 / 10.0) * 0.001 * 50.0);
+    const double h2_v = (1.0 / V_oip2) * Vp1 * Vp1 / std::sqrt(2.0);
+    const double h3_v = (4.0 / (3.0 * V_oip3 * V_oip3)) * Vp1 * Vp1 * Vp1 / 2.0;
+    const double h2_expected = 10.0 * std::log10((h2_v * h2_v / 50.0) / 0.001);
+    const double h3_expected = 10.0 * std::log10((h3_v * h3_v / 50.0) / 0.001);
+
     REQUIRE(out.tones[1].freq_Hz == 200e6);
-    REQUIRE(out.tones[1].power_dBm == Approx(-50.0).epsilon(0.01));
+    REQUIRE(out.tones[1].power_dBm == Approx(h2_expected).epsilon(0.01));
 
     REQUIRE(out.tones[2].freq_Hz == 300e6);
-    REQUIRE(out.tones[2].power_dBm == Approx(-129.5).epsilon(0.1));
+    REQUIRE(out.tones[2].power_dBm == Approx(h3_expected).epsilon(0.1));
 }
 
 TEST_CASE("Amplifier generates two-tone IMD products", "[amplifier][nonlinear]") {

--- a/tests/test_pfb.cpp
+++ b/tests/test_pfb.cpp
@@ -223,3 +223,117 @@ TEST_CASE("PFB channelizer recomputes channels when M increases", "[pfb]") {
     REQUIRE(out.tones.size() <= 1);
     REQUIRE(out.frequencies.size() > 0);
 }
+
+TEST_CASE("PFB channelizer recomputes bin weights when K changes", "[pfb]") {
+    NodeGraphEngine graph;
+    PFBChannelizerEngine pfb(0, graph);
+
+    Spectrum in;
+    in.frequencies.resize(401);
+    for (int i = 0; i < 401; ++i)
+        in.frequencies[i] = -200e6 + i * 1e6;
+    in.noise_total_W.assign(401, 1e-20);
+
+    pfb.setFs_Hz(400e6);
+    pfb.node().inputs[0] = &in;
+    pfb.update(0.0);
+
+    // Copy: a reference into channels() would alias the live vector and see
+    // the recomputed weights regardless.
+    const auto before = pfb.channels()[0].bin_weights;
+    REQUIRE(!before.empty());
+
+    // K enters prototypeResponse() via the sinc argument and the Kaiser window
+    // support, so a K change must re-derive the cached bin_weights that the
+    // noise path applies. Without the fix the guard only watches the frequency
+    // grid/Fs/M and the noise path keeps the old weights.
+    pfb.setTapsPerBranch(16);
+    pfb.update(0.0);
+
+    const auto after = pfb.channels()[0].bin_weights;
+    REQUIRE(after.size() == before.size());
+    bool any_changed = false;
+    for (size_t i = 0; i < before.size(); ++i) {
+        if (after[i] != before[i]) {
+            any_changed = true;
+            break;
+        }
+    }
+    REQUIRE(any_changed);
+}
+
+TEST_CASE("PFB channelizer recomputes bin weights when beta changes", "[pfb]") {
+    NodeGraphEngine graph;
+    PFBChannelizerEngine pfb(0, graph);
+
+    Spectrum in;
+    in.frequencies.resize(401);
+    for (int i = 0; i < 401; ++i)
+        in.frequencies[i] = -200e6 + i * 1e6;
+    in.noise_total_W.assign(401, 1e-20);
+
+    pfb.setFs_Hz(400e6);
+    pfb.node().inputs[0] = &in;
+    pfb.update(0.0);
+
+    // Copy: a reference into channels() would alias the live vector and see
+    // the recomputed weights regardless.
+    const auto before = pfb.channels()[0].bin_weights;
+    REQUIRE(!before.empty());
+
+    // beta shapes the Kaiser window in prototypeResponse(); a beta change must
+    // also re-derive the cached bin_weights used by the noise path.
+    pfb.setKaiserBeta(2.0);
+    pfb.update(0.0);
+
+    const auto after = pfb.channels()[0].bin_weights;
+    REQUIRE(after.size() == before.size());
+    bool any_changed = false;
+    for (size_t i = 0; i < before.size(); ++i) {
+        if (after[i] != before[i]) {
+            any_changed = true;
+            break;
+        }
+    }
+    REQUIRE(any_changed);
+}
+
+TEST_CASE("PFB channelizer severed input clears both outputs and bumps generation", "[pfb]") {
+    NodeGraphEngine graph;
+    PFBChannelizerEngine pfb(0, graph);
+
+    Spectrum in;
+    in.frequencies.resize(401);
+    for (int i = 0; i < 401; ++i)
+        in.frequencies[i] = -200e6 + i * 1e6;
+    in.noise_total_W.assign(401, 1e-20);
+    in.fs_Hz = 400e6;
+
+    pfb.node().inputs[0] = &in;
+    pfb.update(0.0);
+
+    auto &out0 = pfb.node().outputs[0];
+    auto &out1 = pfb.node().outputs[1];
+    REQUIRE(!out0.frequencies.empty());
+    REQUIRE(!out1.frequencies.empty());
+    const uint64_t gen0 = out0.generation;
+    const uint64_t gen1 = out1.generation;
+
+    // Sever the input (empty spectrum): both outputs must empty out and their
+    // generations must advance so downstream (pointer, generation) caches
+    // observe the change instead of serving stale full-band data.
+    Spectrum empty;
+    pfb.node().inputs[0] = &empty;
+    pfb.update(0.0);
+
+    REQUIRE(out0.frequencies.empty());
+    REQUIRE(out0.tones.empty());
+    REQUIRE(out0.noise_W.empty());
+    REQUIRE(out0.noise_total_W.empty());
+    REQUIRE(out1.frequencies.empty());
+    REQUIRE(out1.tones.empty());
+    REQUIRE(out1.noise_W.empty());
+    REQUIRE(out1.noise_total_W.empty());
+    REQUIRE(out0.generation > gen0);
+    REQUIRE(out1.generation > gen1);
+}


### PR DESCRIPTION
## Summary

DSP accuracy fixes from a comprehensive codebase review (findings B1, B4, B5, B6).

- **NonlinearModel harmonic formulas wrong (B1).** H2 = `k1*Vp1/sqrt(2)` was missing a Vp1 factor — the 2nd harmonic scaled 10 dB/decade with input power instead of 20 dB/decade and was ~33 dB too high at typical operating points. H3 = `k2*Vp1^3/4` was 6.02 dB low. Corrected to `k1*Vp1^2/sqrt(2)` and `k2*Vp1^3/2` (derivations in `nonlinear_model.h`); test expectations re-derived from the corrected formulas. This changes every distortion spectrum in the app — intentional.
- **PFB ignores K (taps) and β (Kaiser) changes (B4).** The recompute guard keyed only on freqs/Fs/M, so `setTapsPerBranch`/`setKaiserBeta` left `ch.bin_weights` stale while the tone path used new values — an internally inconsistent spectrum after any K/β edit.
- **PFB severed input leaves stale outputs (B5).** The empty-input path cleared only `outputs[0]`, left `outputs[1]` (full band) stale, and the generation bump was dead code — downstream generation-keyed caches kept serving stale data.
- **IdealFilter drops upstream added noise (B6).** The engine copied `in_ptr->noise_W` into its output, silently deleting an upstream amplifier's added noise (discontinuous noise-floor drop across the filter). Now propagates `noise_total_W`.

Also migrates `pfb_channelizer` and `ideal_filter` onto the new `ComponentEngineBase` (shared id/graph-node/dirty/cached-input boilerplate) since these fixes landed on that structure; the other engines migrate in `refactor/engine-unification`.

## Verification

- `tests.exe`: 220 test cases / 66351 assertions, all pass (216 baseline + 3 PFB + 1 ideal-filter regression tests).
- `test_signal_domain.exe`: 31 cases / 64 assertions, unchanged.
- New tests: PFB K-recompute, PFB beta-recompute, PFB severed-input severs both outputs + bumps generation, IdealFilter preserves upstream added noise.

## Notes for merging

- Includes `common/component_engine_base.h` (identical content also appears in `refactor/engine-unification` — same blob, no conflict).
