### PR TITLE
fix: allow deleting links via Delete key and link context menu

### DIFF
--- a/node_graph/include/node_graph_widget.h
+++ b/node_graph/include/node_graph_widget.h
@@ -66,6 +66,7 @@ class NodeGraphWidget {
     int m_clicked_pin = -1;
     int m_clicked_node = -1;
     int m_context_menu_node = -1;
+    int m_context_menu_link_id = -1;
     bool m_link_created = false;
     float m_click_mouse_x = 0.0f;
     float m_click_mouse_y = 0.0f;
@@ -79,6 +80,9 @@ class NodeGraphWidget {
     void handleLinkDeletion();
     void handleNodeDeletion();
     void handleProbeClick();
+    // Removes a link from the engine and performs the follow-up the editor
+    // needs: group boundary-pin rebuild + onLinkChanged notification.
+    void removeLinkFromEngine(int link_id);
 
     // Subcircuit state
     std::unordered_map<int, int> m_synth_pin_to_real_pin; // rebuilt every frame

--- a/node_graph/src/node_graph_widget.cpp
+++ b/node_graph/src/node_graph_widget.cpp
@@ -314,6 +314,8 @@ void NodeGraphWidget::handleContextMenu(bool editor_hovered) {
                 ImGui::OpenPopup("node_context_menu");
                 m_context_menu_node = hovered_node;
             }
+        } else if (ImNodes::IsLinkHovered(&m_context_menu_link_id)) {
+            ImGui::OpenPopup("link_context_menu");
         } else {
             // Capture mouse position in editor space for component placement
             ImVec2 mouse_screen = ImGui::GetMousePos();
@@ -351,6 +353,13 @@ void NodeGraphWidget::handleContextMenu(bool editor_hovered) {
         if (ImGui::MenuItem("Remove")) {
             if (onRemoveNode)
                 onRemoveNode(m_context_menu_node);
+        }
+        ImGui::EndPopup();
+    }
+
+    if (ImGui::BeginPopup("link_context_menu")) {
+        if (ImGui::MenuItem("Remove")) {
+            removeLinkFromEngine(m_context_menu_link_id);
         }
         ImGui::EndPopup();
     }
@@ -406,19 +415,33 @@ void NodeGraphWidget::handleLinkCreation() {
 
 void NodeGraphWidget::handleLinkDeletion() {
     int link_id;
-    if (ImNodes::IsLinkDestroyed(&link_id)) {
-        m_engine.removeLink(link_id);
-        // Rebuild boundary pins for all groups to reflect the removed link
-        for (const auto &g : m_engine.groups()) {
-            m_engine.rebuildGroupBoundaryPins(g.id);
-        }
-        if (onLinkChanged)
-            onLinkChanged();
+    if (ImNodes::IsLinkDestroyed(&link_id))
+        removeLinkFromEngine(link_id);
+}
+
+void NodeGraphWidget::removeLinkFromEngine(int link_id) {
+    m_engine.removeLink(link_id);
+    // Rebuild boundary pins for all groups to reflect the removed link
+    for (const auto &g : m_engine.groups()) {
+        m_engine.rebuildGroupBoundaryPins(g.id);
     }
+    if (onLinkChanged)
+        onLinkChanged();
 }
 
 void NodeGraphWidget::handleNodeDeletion() {
     if (ImGui::IsKeyPressed(ImGuiKey_Delete)) {
+        // Deleting selected links takes priority over nodes (imnodes clears the
+        // other selection on click, but both may be selected programmatically).
+        int num_selected_links = ImNodes::NumSelectedLinks();
+        if (num_selected_links > 0) {
+            std::vector<int> selected_links(num_selected_links);
+            ImNodes::GetSelectedLinks(selected_links.data());
+            for (int link_id : selected_links)
+                removeLinkFromEngine(link_id);
+            ImNodes::ClearLinkSelection();
+        }
+
         int num_selected = ImNodes::NumSelectedNodes();
         if (num_selected > 0) {
             std::vector<int> selected_nodes(num_selected);

--- a/test_engine/ui_tests.cpp
+++ b/test_engine/ui_tests.cpp
@@ -87,6 +87,132 @@ void RegisterUiTests(ImGuiTestEngine *e, RfSimulatorApp &app) {
     t->TestFunc = [](ImGuiTestContext *ctx) { ctx->WindowFocus("Properties"); };
 
     // =========================================================================
+
+    // Issue #67: selecting a link and pressing Delete must remove it (previously
+    // only selected *nodes* were handled by the Delete key). Runs early, before
+    // the subcircuit tests group/collapse anything, so the seeded Generator
+    // (node 1) and Amplifier (node 2) are still visible and ungrouped.
+    t = IM_REGISTER_TEST(e, "rf_simulator", "link_delete_key_deletes_selected_link");
+    t->TestFunc = [](ImGuiTestContext *ctx) {
+        ctx->WindowFocus("Node Editor");
+        ctx->WindowResize("Node Editor", ImVec2(900, 700));
+        ctx->Yield(2);
+        ImNodes::EditorContextResetPanning(ImVec2(0, 0));
+        ctx->Yield(2);
+
+        auto &graph = s_app->testGraphEngine();
+        size_t initial_links = graph.links().size();
+        int gen_out = graph.outputPinId(1);
+        int amp_in = graph.inputPinId(2);
+        IM_CHECK(gen_out >= 0);
+        IM_CHECK(amp_in >= 0);
+        int link_id = graph.addLink(gen_out, amp_in);
+        IM_CHECK(link_id >= 0);
+        IM_CHECK_EQ(graph.links().size(), initial_links + 1);
+
+        ctx->Yield(4); // let imnodes draw + register the new link
+        ImNodes::ClearNodeSelection();
+        ImNodes::ClearLinkSelection();
+        ImNodes::SelectLink(link_id);
+        ctx->Yield(2);
+        IM_CHECK(ImNodes::IsLinkSelected(link_id));
+
+        ctx->KeyDown(ImGuiKey_Delete);
+        ctx->Yield(2);
+
+        IM_CHECK_EQ(graph.links().size(), initial_links);
+        IM_CHECK_EQ(ImNodes::NumSelectedLinks(), 0);
+    };
+
+    // Issue #67: right-clicking a link must offer a Remove entry (previously the
+    // right-click fell through to the canvas "add component" menu). Uses the
+    // seeded Generator/Amplifier (nodes 1/2), which are visible this early in
+    // the run.
+    t = IM_REGISTER_TEST(e, "rf_simulator", "link_context_menu_remove");
+    t->TestFunc = [](ImGuiTestContext *ctx) {
+        ctx->WindowFocus("Node Editor");
+        ctx->WindowResize("Node Editor", ImVec2(900, 700));
+        ctx->Yield(2);
+        ImNodes::EditorContextResetPanning(ImVec2(0, 0));
+        ctx->Yield(2);
+
+        auto &graph = s_app->testGraphEngine();
+        size_t initial_links = graph.links().size();
+        int gen_out = graph.outputPinId(1);
+        int amp_in = graph.inputPinId(2);
+        IM_CHECK(gen_out >= 0);
+        IM_CHECK(amp_in >= 0);
+
+        // The editor window can be docked anywhere, including mostly below the
+        // viewport, so anchor the node pair to the window's visible top-left
+        // region (inside both the window and the viewport).
+        ImVec2 vp = ImGui::GetIO().DisplaySize;
+        auto info = ctx->WindowInfo("Node Editor");
+        ImVec2 vis_min = info.RectFull.Min;
+        ImVec2 vis_max =
+            ImVec2(std::min(info.RectFull.Max.x, vp.x), std::min(info.RectFull.Max.y, vp.y));
+        float anchor_x = std::min(vis_min.x + 180.0f, vis_max.x - 120.0f);
+        float anchor_y = std::min(vis_min.y + 120.0f, vis_max.y - 120.0f);
+        ImNodes::SetNodeScreenSpacePos(1, ImVec2(anchor_x - 140.0f, anchor_y - 60.0f));
+        ImNodes::SetNodeScreenSpacePos(2, ImVec2(anchor_x + 140.0f, anchor_y + 40.0f));
+        ctx->Yield(4);
+
+        int link_id = graph.addLink(gen_out, amp_in);
+        IM_CHECK(link_id >= 0);
+        IM_CHECK_EQ(graph.links().size(), initial_links + 1);
+        ctx->Yield(4); // let imnodes draw the link
+
+        // Re-focus so the editor window stays the hovered/focused one during
+        // the mouse sweep below.
+        ctx->WindowFocus("Node Editor");
+        ctx->Yield(1);
+
+        // The link's rendered position depends on the node layout (title bar,
+        // body, pin offsets), so locate it by sweeping a 2D grid between the
+        // two nodes until the mouse hovers exactly over our link. The grid is
+        // clamped to the viewport so every point is reachable.
+        ImVec2 n1 = ImNodes::GetNodeScreenSpacePos(1);
+        ImVec2 n2 = ImNodes::GetNodeScreenSpacePos(2);
+        ImVec2 dims1 = ImNodes::GetNodeDimensions(1);
+        float x_min = std::max(n1.x + dims1.x + 8.0f, 10.0f);
+        float x_max = std::min(n2.x - 8.0f, vp.x - 10.0f);
+        float y_min = std::max(n1.y + 55.0f, 10.0f);
+        float y_max = std::min(n2.y + 130.0f, vp.y - 10.0f);
+
+        int hit_x = -1;
+        int hit_y = -1;
+        for (float y = y_min; y < y_max && hit_y < 0; y += 3.0f) {
+            for (float x = x_min; x < x_max && hit_y < 0; x += 10.0f) {
+                ctx->MouseMoveToPos(ImVec2(x, y));
+                ctx->Yield(1);
+                int h = -1;
+                if (ImNodes::IsLinkHovered(&h) && h == link_id) {
+                    hit_x = static_cast<int>(x);
+                    hit_y = static_cast<int>(y);
+                }
+            }
+        }
+        IM_CHECK(hit_y >= 0);
+
+        ctx->MouseClick(ImGuiMouseButton_Right);
+        ctx->Yield(2);
+        IM_CHECK(ImGui::IsPopupOpen((ImGuiID)0, ImGuiPopupFlags_AnyPopup));
+
+        ctx->SetRef("//$FOCUSED");
+        ctx->ItemClick("Remove");
+        ctx->SetRef("");
+        ctx->Yield(2);
+
+        IM_CHECK_EQ(graph.links().size(), initial_links);
+
+        // Restore the seeded nodes to their default origin positions so the
+        // subcircuit tests' "stacked at canvas origin" assumptions hold.
+        ImNodes::SetNodeGridSpacePos(1, ImVec2(0, 0));
+        ImNodes::SetNodeGridSpacePos(2, ImVec2(0, 0));
+        ctx->Yield(2);
+    };
+
+    // =========================================================================
     // Subcircuit Group UI Tests
     // =========================================================================
 
@@ -330,7 +456,6 @@ void RegisterUiTests(ImGuiTestEngine *e, RfSimulatorApp &app) {
         IM_CHECK_EQ(graph.links().size(), initial_links);
     };
 
-    // =========================================================================
     // Validation gap documentation tests
     // These tests document that the engine currently accepts invalid connections.
     // They encode known behavioral gaps — not desired behavior — so they should


### PR DESCRIPTION
## What
Fixes #67 — deleting links between nodes was impossible via the documented gestures.

- **Delete key** on a selected link did nothing: `handleNodeDeletion` only handled selected *nodes*.
- **Right-clicking a link** fell through to the canvas "add component" context menu: `handleContextMenu` only checked `IsNodeHovered`, never `IsLinkHovered`.

## Changes
- `handleNodeDeletion()` now deletes all selected links (`NumSelectedLinks`/`GetSelectedLinks`) before falling back to node deletion, matching the imnodes reference behavior; clears link selection after.
- `handleContextMenu()` opens a new `link_context_menu` with a **Remove** entry when the right-click lands on a link.
- New `removeLinkFromEngine()` helper shared by the detach gesture (middle-click/X), the Delete key, and the context menu — keeps engine removal + group boundary-pin rebuild + `onLinkChanged` notification consistent.

## Tests
Two new UI tests in `test_engine/ui_tests.cpp`:
- `link_delete_key_deletes_selected_link` — select a link, press Delete, assert it's removed.
- `link_context_menu_remove` — right-click a link, click Remove in the context menu, assert it's removed.

Both fail without the fix (reproducing the reported behavior) and pass with it.

## Verification
- `ctest --test-dir build` → **237/237 passed**
- clang-format 18 clean (pre-commit hook + CI format job compatible)
- No CHANGELOG/version bump (done on release commits per convention)