### PR TITLE
fix: format release notes from changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,10 +291,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Generate release notes
+      - name: Generate release notes from changelog
         run: |
-          npm install -g --ignore-scripts git-cliff@2.13.1 --silent
-          git-cliff --config cliff.toml --latest --strip header -o release-notes.md
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v version="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "## [" version "]") == 1) found=1
+            }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "ERROR: CHANGELOG.md has no section for [$VERSION]"
+            exit 1
+          fi
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Verify version matches tag
+      - name: Verify version and changelog entry
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           CMAKE_VERSION=$(grep -oP 'VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
@@ -45,7 +45,11 @@ jobs:
             echo "ERROR: Tag version ($TAG_VERSION) does not match CMakeLists.txt version ($CMAKE_VERSION)"
             exit 1
           fi
-          echo "Version check passed: $TAG_VERSION == $CMAKE_VERSION"
+          if ! grep -qE "^## \[$TAG_VERSION\]([[:space:]]|$)" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md has no section for [$TAG_VERSION]"
+            exit 1
+          fi
+          echo "Version and changelog checks passed for $TAG_VERSION"
 
   strict-build:
     needs: [classify-release, validate-version]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,13 @@ jobs:
             echo "ERROR: Tag version ($TAG_VERSION) does not match CMakeLists.txt version ($CMAKE_VERSION)"
             exit 1
           fi
-          if ! grep -qE "^## \[$TAG_VERSION\]([[:space:]]|$)" CHANGELOG.md; then
+          if ! awk -v version="$TAG_VERSION" '
+            /^## \[/ && index($0, "## [" version "]") == 1 {
+              found=1
+              exit
+            }
+            END { exit !found }
+          ' CHANGELOG.md; then
             echo "ERROR: CHANGELOG.md has no section for [$TAG_VERSION]"
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ Default section order:
 
 ## Release Contract
 
-- `.github/workflows/release.yml` validates tag versions, runs the release matrix, and creates a draft with the matching top-level `CHANGELOG.md` section.
+- `.github/workflows/release.yml` validates tag versions and requires a matching changelog section before running the release matrix or creating a draft.
 - `CHANGELOG.md` is the source of truth for GitHub release descriptions; `cliff.toml` is not used by the release workflow.
 
 ## Child DOX Index

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,11 @@ Default section order:
 - When the user requests a durable behavior change, record it here or in the relevant child AGENTS.md
 - Superpowers plan/spec documents are working materials and must not be committed.
 
+## Release Contract
+
+- `.github/workflows/release.yml` validates tag versions, runs the release matrix, and creates a draft with the matching top-level `CHANGELOG.md` section.
+- `CHANGELOG.md` is the source of truth for GitHub release descriptions; `cliff.toml` is not used by the release workflow.
+
 ## Child DOX Index
 
 - [common/AGENTS.md](common/AGENTS.md) — Header-only data model shared by all modules (`SignalNode`, `Spectrum`, `IComponentEngine`, `Group`, `GroupBoundaryPin`, etc.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,16 @@ Minor and major release tags (`vX.Y.0`, including `vX.0.0`) trigger the stricter
 
 Patch release tags (`vX.Y.Z` where `Z > 0`) still build/package Linux and Windows artifacts, but skip the strict validation matrix.
 
+### Release Process
+
+Release tags are pushed only after the version commit is on `master`:
+
+1. Update `CMakeLists.txt` and add the matching `## [X.Y.Z]` section at the top of `CHANGELOG.md`.
+2. Push `master`, then create and push the annotated `vX.Y.Z` tag.
+3. The release workflow validates the tag against `CMakeLists.txt`, runs the applicable build/test matrix, and packages Linux and Windows binaries.
+4. The workflow extracts the matching `CHANGELOG.md` section as the draft release description. `CHANGELOG.md` is the release-note source of truth; `cliff.toml` is for standalone git-cliff generation only.
+5. Review and publish the generated GitHub draft after the workflow succeeds.
+
 ## Architecture (Quick Reference)
 
 - **C++20** modular library.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Patch release tags (`vX.Y.Z` where `Z > 0`) still build/package Linux and Window
 
 ### Release Process
 
-Release tags are pushed only after the version commit is on `master`:
+Every release tag, including patch tags, requires a matching changelog entry before it is pushed:
 
 1. Update `CMakeLists.txt` and add the matching `## [X.Y.Z]` section at the top of `CHANGELOG.md`.
 2. Push `master`, then create and push the annotated `vX.Y.Z` tag.

--- a/cliff.toml
+++ b/cliff.toml
@@ -4,18 +4,18 @@
 [changelog]
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
-    ## [unreleased]
+## [unreleased]
 {% endif %}\
-{% for group, commits in commits | group_by(attribute="group") %}
-    ### {{ group | striptags | trim | upper_first }}
-    {% for commit in commits %}
-        - {% if commit.scope %}_({{ commit.scope }})_{% endif %}\
-            {% if commit.breaking %}[**breaking**] {% endif %}\
-            {{ commit.message | upper_first }}\
-    {% endfor %}
-{% endfor %}
+{% for group, commits in commits | group_by(attribute="group") -%}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits -%}
+- {% if commit.scope %}_({{ commit.scope }})_{% endif %}\
+    {% if commit.breaking %}[**breaking**] {% endif %}\
+    {{ commit.message | upper_first }}\
+{% endfor -%}
+{% endfor -%}
 """
 trim = true
 render_always = true


### PR DESCRIPTION
## Summary
- Generate release descriptions from the matching top-level `CHANGELOG.md` section
- Keep git-cliff output structurally formatted for standalone use
- Document release-note source of truth and draft publication flow

## Verification
- YAML and TOML parsed successfully
- Changelog extraction verified for v0.21.0
- git-cliff 2.13.1 rendered separate headings and bullets