### PR TITLE
feat: add PFB sampling ratio control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ Default section order:
 - The PFB channelizer is physically downstream of an RF ADC only; direct RF-chain-to-PFB links must be rejected.
 
 - ADC DDC decimation is configurable as 1/2/4/8 and NCO tuning is stored as a normalized factor of the ADC input sample rate; legacy ADC state defaults to decimation 2 and NCO +0.25×Fs.
+- PFB channelizers default to critical sampling (1x) and support a persisted 2x oversampling ratio; channel output `fs_Hz` is `ratio * input Fs / M`, with channel centers unchanged and usable channel bandwidth scaled by the ratio.
 - When the user requests a durable behavior change, record it here or in the relevant child AGENTS.md
 - Superpowers plan/spec documents are working materials and must not be committed.
 

--- a/app/src/inspector_panel.cpp
+++ b/app/src/inspector_panel.cpp
@@ -766,6 +766,17 @@ void InspectorPanel::drawPFBProperties(PFBChannelizerEngine &engine) {
         engine.setKaiserBeta(beta);
         m_param_edited = true;
     }
+    const char *sampling_labels[] = {"1x (critical)", "2x (oversampled)"};
+    int sampling_ratio = engine.samplingRatio() - 1;
+    if (ImGui::Combo("Sampling Ratio", &sampling_ratio, sampling_labels, 2)) {
+        engine.setSamplingRatio(sampling_ratio + 1);
+        m_param_edited = true;
+    }
+    if (engine.outputFs_Hz() > 0.0) {
+        ImGui::Text("Channel output Fs: %.3f MHz", engine.outputFs_Hz() / 1e6);
+    } else {
+        ImGui::TextDisabled("Channel output Fs: waiting for ADC input");
+    }
 
     if (ImGui::SliderInt("Active Channel", &ch, 0, engine.channelCount() - 1)) {
         engine.setActiveChannel(ch);

--- a/pfb_channelizer/include/pfb_channelizer_engine.h
+++ b/pfb_channelizer/include/pfb_channelizer_engine.h
@@ -24,6 +24,7 @@ struct PFBConfig {
     int K = 8;
     double Fs_Hz = 0.0;
     double beta = 8.0;
+    int sampling_ratio = 1;
 };
 
 class PFBChannelizerEngine : public ComponentEngineBase {
@@ -39,6 +40,7 @@ class PFBChannelizerEngine : public ComponentEngineBase {
     void setChannelCount(int M);
     void setTapsPerBranch(int K);
     void setKaiserBeta(double beta);
+    void setSamplingRatio(int ratio);
     void setActiveChannel(int ch);
     void setFs_Hz(double fs) {
         if (fs != m_cfg.Fs_Hz || m_fs_from_input) {
@@ -51,8 +53,13 @@ class PFBChannelizerEngine : public ComponentEngineBase {
     int channelCount() const { return m_cfg.M; }
     int tapsPerBranch() const { return m_cfg.K; }
     double kaiserBeta() const { return m_cfg.beta; }
+    int samplingRatio() const { return m_cfg.sampling_ratio; }
     int activeChannel() const { return m_active_channel; }
     double fs_Hz() const { return m_cfg.Fs_Hz; }
+    double outputFs_Hz() const {
+        return m_cfg.Fs_Hz > 0.0 ? m_cfg.Fs_Hz * static_cast<double>(m_cfg.sampling_ratio) / m_cfg.M
+                                 : 0.0;
+    }
     const std::vector<PFBChannel> &channels() const { return m_channels; }
 
     double activeChannelCenter_Hz() const {
@@ -77,6 +84,7 @@ class PFBChannelizerEngine : public ComponentEngineBase {
     std::vector<double> m_cached_freqs;
     double m_cached_Fs_Hz = 0;
     int m_cached_K = 0;
+    int m_cached_sampling_ratio = 0;
     double m_cached_beta = 0.0;
     bool m_fs_from_input = false;
 

--- a/pfb_channelizer/include/pfb_channelizer_widget.h
+++ b/pfb_channelizer/include/pfb_channelizer_widget.h
@@ -16,6 +16,8 @@ class PFBChannelizerWidget {
     PFBChannelizerEngine &m_engine;
     int m_grid_offset = 0;
     uint64_t m_cached_gen = 0;
+    int m_cached_grid_offset = 0;
+    uint64_t m_cached_output_gen = 0;
     const Spectrum *m_cached_input = nullptr;
 
     struct CellCache {

--- a/pfb_channelizer/src/pfb_channelizer_engine.cpp
+++ b/pfb_channelizer/src/pfb_channelizer_engine.cpp
@@ -140,6 +140,8 @@ void PFBChannelizerEngine::update(double) {
 
     double bin_width =
         (in_ptr->frequencies.size() > 1) ? in_ptr->frequencies[1] - in_ptr->frequencies[0] : 1.0;
+    const double channel_spacing = m_cfg.Fs_Hz / m_cfg.M;
+    const double channel_bw = channel_spacing * static_cast<double>(m_cfg.sampling_ratio);
 
     for (auto &ch : m_channels) {
         ch.noise_W = 0.0;
@@ -159,7 +161,7 @@ void PFBChannelizerEngine::update(double) {
             double offset = tone.freq_Hz - ch.center_freq_Hz;
             if (std::abs(offset) <= ch.bandwidth_Hz) {
                 Spectrum::Tone t = tone;
-                double w = m_design.responseAt(offset / (m_cfg.Fs_Hz / m_cfg.M));
+                double w = m_design.responseAt(offset / channel_bw);
                 double power_lin = std::pow(10.0, tone.power_dBm / 10.0) * w * w;
                 t.power_dBm = 10.0 * std::log10(power_lin + 1e-300);
                 ch.tones.push_back(t);
@@ -208,7 +210,6 @@ void PFBChannelizerEngine::update(double) {
     out_full.noise_total_W.assign(n_full, 0.0);
     out_full.noise_added_W.assign(n_full, 0.0);
     std::vector<int> overlap_count(n_full, 0);
-    double channel_bw = m_cfg.Fs_Hz * static_cast<double>(m_cfg.sampling_ratio) / m_cfg.M;
     // Accumulate PSD (W/Hz), not per-bin power. Each channel's noise density
     // is total channel noise power divided by the channel bandwidth, then
     // averaged across overlapping channels to produce a flat combined band.
@@ -281,7 +282,7 @@ void PFBChannelizerEngine::recomputeChannels(const std::vector<double> &freqs) {
             double offset = freqs[i] - ch.center_freq_Hz;
             if (std::abs(offset) <= channel_bw) {
                 ch.bin_indices.push_back(i);
-                ch.bin_weights.push_back(m_design.responseAt(offset / channel_spacing));
+                ch.bin_weights.push_back(m_design.responseAt(offset / channel_bw));
             }
         }
     }

--- a/pfb_channelizer/src/pfb_channelizer_engine.cpp
+++ b/pfb_channelizer/src/pfb_channelizer_engine.cpp
@@ -55,6 +55,14 @@ void PFBChannelizerEngine::setKaiserBeta(double beta) {
     }
 }
 
+void PFBChannelizerEngine::setSamplingRatio(int ratio) {
+    ratio = std::clamp(ratio, 1, 2);
+    if (ratio != m_cfg.sampling_ratio) {
+        m_cfg.sampling_ratio = ratio;
+        m_dirty = true;
+    }
+}
+
 void PFBChannelizerEngine::setActiveChannel(int ch) {
     if (ch < 0)
         ch = 0;
@@ -94,6 +102,7 @@ void PFBChannelizerEngine::update(double) {
         out.tones.clear();
         out.noise_W.clear();
         out.noise_total_W.clear();
+        out.fs_Hz = outputFs_Hz();
         out.bumpGeneration();
         out.is_complex_baseband = in_ptr ? in_ptr->is_complex_baseband : false;
         // Sever the full-band output too: it previously retained the last
@@ -106,6 +115,7 @@ void PFBChannelizerEngine::update(double) {
         out_full.noise_total_W.clear();
         out_full.noise_added_W.clear();
         out_full.phase_deg.clear();
+        out_full.fs_Hz = m_cfg.Fs_Hz;
         out_full.is_complex_baseband = in_ptr ? in_ptr->is_complex_baseband : false;
         out_full.bumpGeneration();
         return;
@@ -118,12 +128,14 @@ void PFBChannelizerEngine::update(double) {
     // spectrum.
     if (in_ptr->frequencies != m_cached_freqs || m_cfg.Fs_Hz != m_cached_Fs_Hz ||
         m_cfg.K != m_cached_K || m_cfg.beta != m_cached_beta ||
+        m_cfg.sampling_ratio != m_cached_sampling_ratio ||
         m_channels.size() != static_cast<size_t>(m_cfg.M)) {
         recomputeChannels(in_ptr->frequencies);
         m_cached_freqs = in_ptr->frequencies;
         m_cached_Fs_Hz = m_cfg.Fs_Hz;
         m_cached_K = m_cfg.K;
         m_cached_beta = m_cfg.beta;
+        m_cached_sampling_ratio = m_cfg.sampling_ratio;
     }
 
     double bin_width =
@@ -161,6 +173,7 @@ void PFBChannelizerEngine::update(double) {
     out.noise_W.resize(n, 0.0);
     out.noise_total_W.resize(n, 0.0);
     out.phase_deg.resize(n, 0.0);
+    out.fs_Hz = outputFs_Hz();
     out.tones = active.tones;
     out.is_complex_baseband = in_ptr ? in_ptr->is_complex_baseband : false;
 
@@ -188,13 +201,14 @@ void PFBChannelizerEngine::update(double) {
     // removes ripple from overlapping channel contributions.
     auto &out_full = m_node.outputs[1];
     out_full.frequencies = in_ptr->frequencies;
+    out_full.fs_Hz = m_cfg.Fs_Hz;
 
     size_t n_full = in_ptr->frequencies.size();
     out_full.noise_W.assign(n_full, 0.0);
     out_full.noise_total_W.assign(n_full, 0.0);
     out_full.noise_added_W.assign(n_full, 0.0);
     std::vector<int> overlap_count(n_full, 0);
-    double channel_bw = m_cfg.Fs_Hz / m_cfg.M;
+    double channel_bw = m_cfg.Fs_Hz * static_cast<double>(m_cfg.sampling_ratio) / m_cfg.M;
     // Accumulate PSD (W/Hz), not per-bin power. Each channel's noise density
     // is total channel noise power divided by the channel bandwidth, then
     // averaged across overlapping channels to produce a flat combined band.
@@ -219,18 +233,17 @@ void PFBChannelizerEngine::update(double) {
     // Each input tone should appear once in the full-band output. Overlapping
     // channel filters produce multiple representations of the same tone; keep
     // the strongest filtered representation rather than exposing duplicates.
-    // A channel only sees tones within +/-channel_bw of its centre, so a
-    // duplicate of one of channel k's tones can only have been appended by
-    // channels k-2..k (k itself only when the input carries duplicate
-    // frequencies). Restricting the search to those runs avoids re-scanning
-    // the whole accumulated tone list on every occurrence.
+    // A channel only sees tones within +/-channel_bw of its centre. Search
+    // only the recent channel runs that can overlap the current one; this
+    // keeps duplicate suppression bounded while supporting oversampling.
     out_full.tones.clear();
-    size_t run_start_k2 = 0; // where channel k-2's appends begin (search window)
-    size_t run_start_k1 = 0; // where channel k-1's appends begin
+    const size_t overlap_channels = static_cast<size_t>(2 * m_cfg.sampling_ratio);
+    std::vector<size_t> run_starts(m_channels.size(), 0);
     for (size_t k = 0; k < m_channels.size(); ++k) {
         const auto &ch = m_channels[k];
         const size_t run_start = out_full.tones.size();
-        const size_t window_begin = (k >= 2) ? run_start_k2 : 0;
+        run_starts[k] = run_start;
+        const size_t window_begin = (k >= overlap_channels) ? run_starts[k - overlap_channels] : 0;
         for (const auto &tone : ch.tones) {
             auto existing =
                 std::find_if(out_full.tones.begin() + static_cast<std::ptrdiff_t>(window_begin),
@@ -242,8 +255,6 @@ void PFBChannelizerEngine::update(double) {
             else if (tone.power_dBm > existing->power_dBm)
                 *existing = tone;
         }
-        run_start_k2 = run_start_k1;
-        run_start_k1 = run_start;
     }
 
     out_full.bumpGeneration();
@@ -251,14 +262,15 @@ void PFBChannelizerEngine::update(double) {
 
 void PFBChannelizerEngine::recomputeChannels(const std::vector<double> &freqs) {
     m_design = PfbFilterDesign(m_cfg.M, m_cfg.K, m_cfg.beta);
-    double channel_bw = m_cfg.Fs_Hz / m_cfg.M;
+    double channel_spacing = m_cfg.Fs_Hz / m_cfg.M;
+    double channel_bw = channel_spacing * static_cast<double>(m_cfg.sampling_ratio);
     double nyquist = m_cfg.Fs_Hz / 2.0;
     m_channels.resize(m_cfg.M);
 
     for (int k = 0; k < m_cfg.M; ++k) {
         auto &ch = m_channels[k];
         ch.channel_index = k;
-        ch.center_freq_Hz = -nyquist + channel_bw / 2.0 + k * channel_bw;
+        ch.center_freq_Hz = -nyquist + channel_spacing / 2.0 + k * channel_spacing;
         ch.bandwidth_Hz = channel_bw;
         ch.bin_indices.clear();
         ch.bin_weights.clear();
@@ -269,7 +281,7 @@ void PFBChannelizerEngine::recomputeChannels(const std::vector<double> &freqs) {
             double offset = freqs[i] - ch.center_freq_Hz;
             if (std::abs(offset) <= channel_bw) {
                 ch.bin_indices.push_back(i);
-                ch.bin_weights.push_back(m_design.responseAt(offset / channel_bw));
+                ch.bin_weights.push_back(m_design.responseAt(offset / channel_spacing));
             }
         }
     }
@@ -279,6 +291,7 @@ nlohmann::json PFBChannelizerEngine::serialize() const {
     return {{"channel_count", m_cfg.M},
             {"taps_per_branch", m_cfg.K},
             {"kaiser_beta", m_cfg.beta},
+            {"sampling_ratio", m_cfg.sampling_ratio},
             {"active_channel", m_active_channel}};
 }
 
@@ -290,6 +303,7 @@ void PFBChannelizerEngine::deserialize(const nlohmann::json &j) {
         m_cfg.M = 2048;
     m_cfg.K = std::clamp(j.value("taps_per_branch", 8), 1, 64);
     m_cfg.beta = std::clamp(j.value("kaiser_beta", 8.0), 0.0, 20.0);
+    m_cfg.sampling_ratio = std::clamp(j.value("sampling_ratio", 1), 1, 2);
     m_active_channel = j.value("active_channel", 0);
     if (m_active_channel < 0)
         m_active_channel = 0;
@@ -300,5 +314,6 @@ void PFBChannelizerEngine::deserialize(const nlohmann::json &j) {
 
 std::string PFBChannelizerEngine::hoverSummary() const {
     return "PFB M=" + std::to_string(m_cfg.M) + " K=" + std::to_string(m_cfg.K) +
-           " Ch=" + std::to_string(m_active_channel);
+           " Ch=" + std::to_string(m_active_channel) +
+           " OS=" + std::to_string(m_cfg.sampling_ratio) + "x";
 }

--- a/pfb_channelizer/src/pfb_channelizer_widget.cpp
+++ b/pfb_channelizer/src/pfb_channelizer_widget.cpp
@@ -13,6 +13,8 @@ void PFBChannelizerWidget::rebuildCache() {
     if (!in || in->frequencies.size() < 2) {
         m_cells.clear();
         m_cached_gen = in ? in->generation : 0;
+        m_cached_output_gen = m_engine.node().outputs[0].generation;
+        m_cached_grid_offset = m_grid_offset;
         return;
     }
 
@@ -66,6 +68,8 @@ void PFBChannelizerWidget::rebuildCache() {
     m_y_max += 3.0;
 
     m_cached_gen = in->generation;
+    m_cached_output_gen = m_engine.node().outputs[0].generation;
+    m_cached_grid_offset = m_grid_offset;
 }
 
 void PFBChannelizerWidget::draw(const char *title, bool *p_open) {
@@ -94,7 +98,9 @@ void PFBChannelizerWidget::draw(const char *title, bool *p_open) {
         m_grid_offset = 0;
     }
 
-    if (in != m_cached_input || in->generation != m_cached_gen)
+    if (in != m_cached_input || in->generation != m_cached_gen ||
+        m_grid_offset != m_cached_grid_offset ||
+        m_engine.node().outputs[0].generation != m_cached_output_gen)
         rebuildCache();
 
     ImDrawList *dl = ImGui::GetWindowDrawList();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -214,3 +214,9 @@ add_standalone_test(test_issue80_extension_hardening
     SOURCES test_issue80_extension_hardening.cpp
     LIBS simulator::app
 )
+# Standalone sampling-ratio coverage stays outside tests.exe because of the
+# MinGW-w64 registration ceiling.
+add_standalone_test(test_pfb_sampling_ratio
+    SOURCES test_pfb_sampling_ratio.cpp
+    LIBS simulator::pfb_channelizer_engine simulator::node_graph_engine
+)

--- a/tests/test_pfb_sampling_ratio.cpp
+++ b/tests/test_pfb_sampling_ratio.cpp
@@ -1,0 +1,83 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <nlohmann/json.hpp>
+
+#include "node_graph_engine.h"
+#include "pfb_channelizer_engine.h"
+
+using Catch::Approx;
+
+namespace {
+Spectrum makeInput(double fs_Hz) {
+    Spectrum input;
+    input.frequencies.resize(401);
+    for (int i = 0; i < 401; ++i)
+        input.frequencies[i] = -fs_Hz / 2.0 + static_cast<double>(i) * fs_Hz / 400.0;
+    input.noise_total_W.assign(input.frequencies.size(), 1e-20);
+    input.fs_Hz = fs_Hz;
+    return input;
+}
+} // namespace
+
+TEST_CASE("PFB defaults to critically sampled output", "[pfb][sampling_ratio]") {
+    NodeGraphEngine graph;
+    PFBChannelizerEngine pfb(0, graph);
+    auto input = makeInput(400e6);
+    pfb.node().inputs[0] = &input;
+    pfb.update(0.0);
+
+    REQUIRE(pfb.samplingRatio() == 1);
+    REQUIRE(pfb.outputFs_Hz() == Approx(12.5e6));
+    REQUIRE(pfb.activeChannelBandwidth_Hz() == Approx(12.5e6));
+    REQUIRE(pfb.node().outputs[0].fs_Hz == Approx(12.5e6));
+    REQUIRE(pfb.node().outputs[1].fs_Hz == Approx(400e6));
+}
+
+TEST_CASE("PFB ratio two doubles channel output rate and bandwidth", "[pfb][sampling_ratio]") {
+    NodeGraphEngine graph;
+    PFBChannelizerEngine pfb(0, graph);
+    auto input = makeInput(400e6);
+    pfb.node().inputs[0] = &input;
+    pfb.update(0.0);
+
+    pfb.setSamplingRatio(2);
+    pfb.update(0.0);
+
+    REQUIRE(pfb.samplingRatio() == 2);
+    REQUIRE(pfb.outputFs_Hz() == Approx(25e6));
+    REQUIRE(pfb.activeChannelBandwidth_Hz() == Approx(25e6));
+    REQUIRE(pfb.channels()[16].center_freq_Hz == Approx(6.25e6).margin(1.0));
+    REQUIRE(pfb.channels()[17].center_freq_Hz - pfb.channels()[16].center_freq_Hz ==
+            Approx(12.5e6).margin(1.0));
+    REQUIRE(pfb.node().outputs[0].fs_Hz == Approx(25e6));
+}
+
+TEST_CASE("PFB sampling ratio accepts only one or two", "[pfb][sampling_ratio]") {
+    NodeGraphEngine graph;
+    PFBChannelizerEngine pfb(0, graph);
+
+    pfb.setSamplingRatio(0);
+    REQUIRE(pfb.samplingRatio() == 1);
+    pfb.setSamplingRatio(7);
+    REQUIRE(pfb.samplingRatio() == 2);
+}
+
+TEST_CASE("PFB sampling ratio is persisted with legacy default", "[pfb][sampling_ratio]") {
+    NodeGraphEngine graph;
+    PFBChannelizerEngine pfb(0, graph);
+    pfb.setSamplingRatio(2);
+    const auto saved = pfb.serialize();
+    REQUIRE(saved.at("sampling_ratio") == 2);
+
+    PFBChannelizerEngine restored(1, graph);
+    restored.deserialize(saved);
+    REQUIRE(restored.samplingRatio() == 2);
+
+    PFBChannelizerEngine legacy(2, graph);
+    legacy.deserialize(nlohmann::json::object());
+    REQUIRE(legacy.samplingRatio() == 1);
+
+    PFBChannelizerEngine invalid(3, graph);
+    invalid.deserialize({{"sampling_ratio", 99}});
+    REQUIRE(invalid.samplingRatio() == 2);
+}

--- a/tests/test_pfb_sampling_ratio.cpp
+++ b/tests/test_pfb_sampling_ratio.cpp
@@ -52,6 +52,40 @@ TEST_CASE("PFB ratio two doubles channel output rate and bandwidth", "[pfb][samp
     REQUIRE(pfb.node().outputs[0].fs_Hz == Approx(25e6));
 }
 
+TEST_CASE("PFB oversampling preserves full-band flat-noise density", "[pfb][sampling_ratio]") {
+    NodeGraphEngine graph;
+    PFBChannelizerEngine pfb(0, graph);
+    auto input = makeInput(400e6);
+    pfb.node().inputs[0] = &input;
+
+    pfb.update(0.0);
+    const double critical_psd = pfb.node().outputs[1].noise_total_W.at(200);
+    REQUIRE(critical_psd > 0.0);
+
+    pfb.setSamplingRatio(2);
+    pfb.update(0.0);
+    const double oversampled_psd = pfb.node().outputs[1].noise_total_W.at(200);
+
+    REQUIRE(oversampled_psd / critical_psd == Approx(1.0).epsilon(0.05));
+}
+
+TEST_CASE("PFB oversampling widens the usable channel response", "[pfb][sampling_ratio]") {
+    NodeGraphEngine graph;
+    PFBChannelizerEngine pfb(0, graph);
+    auto input = makeInput(400e6);
+    input.tones.push_back({18.25e6, -30.0, 0.0});
+    pfb.node().inputs[0] = &input;
+
+    pfb.update(0.0);
+    const double critical_tone = pfb.channels().at(16).tones.front().power_dBm;
+
+    pfb.setSamplingRatio(2);
+    pfb.update(0.0);
+    const double oversampled_tone = pfb.channels().at(16).tones.front().power_dBm;
+
+    REQUIRE(oversampled_tone > critical_tone + 20.0);
+}
+
 TEST_CASE("PFB sampling ratio accepts only one or two", "[pfb][sampling_ratio]") {
     NodeGraphEngine graph;
     PFBChannelizerEngine pfb(0, graph);


### PR DESCRIPTION
## Summary
Adds a persisted PFB sampling-ratio control with critically sampled (1x) and 2x oversampled modes. The inspector exposes the setting and active channel output rate; channel centers remain fixed while usable bandwidth scales with the ratio.

## Related issue
N/A

## Type of change

- [x] New feature
- [x] Documentation

## Test plan

- [x] `cmake --build build --target tests test_pfb_filter_design test_pfb_sampling_ratio`
- [x] `ctest --test-dir build -R pfb --output-on-failure` — 5/5 passed
- [x] New standalone sampling-ratio tests — 17 assertions passed
- [x] Existing PFB tests — 480 assertions passed
- [x] PFB filter-design tests — 594 assertions passed
- [x] clang-format dry-run on changed C++ files

The full project-wide CTest suite was not rerun; CI should provide that gate.

## Checklist

- [x] Changes are split into atomic commits
- [x] Ran clang-format on changed C++ files
- [x] Added focused regression tests
- [x] Existing focused PFB tests pass