### PR TITLE
fix: clean up DSP frame-loop allocations

### DIFF
--- a/app/include/component_registry.h
+++ b/app/include/component_registry.h
@@ -31,7 +31,7 @@ class ComponentRegistry {
 
             auto type_it = m_type_index.find(type);
             if (type_it == m_type_index.end()) {
-                type_it = m_type_index.emplace(type, std::vector<IComponentEngine *> {}).first;
+                type_it = m_type_index.emplace(type, std::vector<IComponentEngine *>{}).first;
                 type_entry_added = true;
             }
             type_it->second.push_back(static_cast<IComponentEngine *>(ptr));

--- a/app/include/component_registry.h
+++ b/app/include/component_registry.h
@@ -5,6 +5,7 @@
 #include "view_manager.h"
 #include <memory>
 #include <span>
+#include <stdexcept>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
@@ -17,10 +18,49 @@ class ComponentRegistry {
     template <typename T, typename... Args> T &add(Args &&...args) {
         auto comp = std::make_unique<T>(std::forward<Args>(args)...);
         T *ptr = comp.get();
-        m_view.registerNode(&ptr->node());
-        m_type_index[std::type_index(typeid(T))].push_back(static_cast<IComponentEngine *>(ptr));
-        m_components.push_back(std::move(comp));
-        rebuildView();
+        const int graph_node_id = ptr->graphNodeId();
+        const auto type = std::type_index(typeid(T));
+        bool view_registered = false;
+        bool type_entry_added = false;
+        bool type_ptr_added = false;
+        bool graph_index_added = false;
+        bool component_added = false;
+        try {
+            m_view.registerNode(&ptr->node());
+            view_registered = true;
+
+            auto type_it = m_type_index.find(type);
+            if (type_it == m_type_index.end()) {
+                type_it = m_type_index.emplace(type, std::vector<IComponentEngine *> {}).first;
+                type_entry_added = true;
+            }
+            type_it->second.push_back(static_cast<IComponentEngine *>(ptr));
+            type_ptr_added = true;
+
+            auto [graph_it, inserted] = m_graph_index.emplace(graph_node_id, ptr);
+            (void)graph_it;
+            if (!inserted)
+                throw std::logic_error("duplicate component graph node ID");
+            graph_index_added = true;
+
+            m_components.push_back(std::move(comp));
+            component_added = true;
+            rebuildView();
+        } catch (...) {
+            if (view_registered)
+                m_view.unregisterNode(&ptr->node());
+            m_graph.removeNodeForSignalNode(&ptr->node());
+            if (component_added)
+                m_components.pop_back();
+            if (graph_index_added)
+                m_graph_index.erase(graph_node_id);
+            auto type_it = m_type_index.find(type);
+            if (type_ptr_added && type_it != m_type_index.end())
+                type_it->second.pop_back();
+            if (type_entry_added && type_it != m_type_index.end() && type_it->second.empty())
+                m_type_index.erase(type_it);
+            throw;
+        }
         return *ptr;
     }
 
@@ -50,4 +90,5 @@ class ComponentRegistry {
     std::vector<std::unique_ptr<IComponentEngine>> m_components;
     std::vector<IComponentEngine *> m_all_view;
     std::unordered_map<std::type_index, std::vector<IComponentEngine *>> m_type_index;
+    std::unordered_map<int, IComponentEngine *> m_graph_index;
 };

--- a/app/src/app.cpp
+++ b/app/src/app.cpp
@@ -659,16 +659,10 @@ void RfSimulatorApp::rewireInputs() {
 void RfSimulatorApp::update_dsp() {
     rewireInputs();
 
-    std::unordered_map<int, std::function<void()>> updates;
-    for (auto *comp : m_components.all()) {
-        updates[comp->graphNodeId()] = [comp]() { comp->update(0.0); };
-    }
-
     auto order = m_graph_engine.topologicalOrder();
     for (int node_id : order) {
-        auto it = updates.find(node_id);
-        if (it != updates.end())
-            it->second();
+        if (auto *comp = m_components.find(node_id))
+            comp->update(0.0);
     }
 
     // Update spectrum view based on probed pins. Each probe resolves to a

--- a/app/src/component_registry.cpp
+++ b/app/src/component_registry.cpp
@@ -10,12 +10,13 @@ bool ComponentRegistry::remove(int graphNodeId) {
         if (m_components[i]->graphNodeId() == graphNodeId) {
             IComponentEngine *comp = m_components[i].get();
             m_view.unregisterNode(&comp->node());
-            m_graph.removeNode(graphNodeId);
+            m_graph.removeNodeForSignalNode(&comp->node());
 
             auto &idx = m_type_index[std::type_index(typeid(*comp))];
             idx.erase(std::remove(idx.begin(), idx.end(), static_cast<IComponentEngine *>(comp)),
                       idx.end());
 
+            m_graph_index.erase(graphNodeId);
             m_components.erase(m_components.begin() + static_cast<std::ptrdiff_t>(i));
             rebuildView();
             LOG_INFO("Removed component (graph node %d)", graphNodeId);
@@ -27,11 +28,8 @@ bool ComponentRegistry::remove(int graphNodeId) {
 }
 
 IComponentEngine *ComponentRegistry::find(int graphNodeId) const {
-    for (auto &comp : m_components) {
-        if (comp->graphNodeId() == graphNodeId)
-            return comp.get();
-    }
-    return nullptr;
+    auto it = m_graph_index.find(graphNodeId);
+    return it != m_graph_index.end() ? it->second : nullptr;
 }
 
 std::string ComponentRegistry::hoverSummary(int graphNodeId) const {
@@ -40,8 +38,9 @@ std::string ComponentRegistry::hoverSummary(int graphNodeId) const {
 }
 
 void ComponentRegistry::rebuildView() {
-    m_all_view.clear();
-    m_all_view.reserve(m_components.size());
+    std::vector<IComponentEngine *> new_view;
+    new_view.reserve(m_components.size());
     for (auto &comp : m_components)
-        m_all_view.push_back(comp.get());
+        new_view.push_back(comp.get());
+    m_all_view.swap(new_view);
 }

--- a/node_graph/include/node_graph_engine.h
+++ b/node_graph/include/node_graph_engine.h
@@ -36,6 +36,7 @@ class NodeGraphEngine {
   public:
     int addNode(const std::string &label, SignalNode *signal_node, int num_inputs, int num_outputs);
     void removeNode(int node_id);
+    void removeNodeForSignalNode(SignalNode *signal_node);
 
     int addLink(int start_pin, int end_pin);
     void removeLink(int link_id);

--- a/node_graph/include/node_graph_engine.h
+++ b/node_graph/include/node_graph_engine.h
@@ -110,6 +110,7 @@ class NodeGraphEngine {
     std::unordered_map<int, std::vector<int>> m_node_to_group_cache;
 
     void rebuildNodeToGroupCache();
+    void removeNodeAt(std::vector<GraphNode>::iterator it);
 };
 
 // View-layer component type. Used by NodeGraphWidget to pick a color and

--- a/node_graph/include/node_graph_widget.h
+++ b/node_graph/include/node_graph_widget.h
@@ -127,5 +127,4 @@ class NodeGraphWidget {
     void detectNodeMoves();
     void handleRubberBand(bool editor_hovered);
     void handleGroupSelection();
-    size_t findNodeIndex(int node_id) const;
 };

--- a/node_graph/src/node_graph_engine.cpp
+++ b/node_graph/src/node_graph_engine.cpp
@@ -28,15 +28,18 @@ void NodeGraphEngine::removeNode(int node_id) {
     auto it = std::find_if(m_nodes.begin(), m_nodes.end(),
                            [node_id](const GraphNode &n) { return n.node_id == node_id; });
     if (it != m_nodes.end())
-        removeNodeForSignalNode(it->signal_node);
+        removeNodeAt(it);
 }
 
 void NodeGraphEngine::removeNodeForSignalNode(SignalNode *signal_node) {
-    auto it = std::find_if(
-        m_nodes.begin(), m_nodes.end(),
-        [signal_node](const GraphNode &n) { return n.signal_node == signal_node; });
-    if (it == m_nodes.end())
-        return;
+    auto it = std::find_if(m_nodes.begin(), m_nodes.end(), [signal_node](const GraphNode &n) {
+        return n.signal_node == signal_node;
+    });
+    if (it != m_nodes.end())
+        removeNodeAt(it);
+}
+
+void NodeGraphEngine::removeNodeAt(std::vector<GraphNode>::iterator it) {
     const int node_id = it->node_id;
 
     LOG_INFO("Removed node '%s' (id=%d)", it->label.c_str(), node_id);

--- a/node_graph/src/node_graph_engine.cpp
+++ b/node_graph/src/node_graph_engine.cpp
@@ -27,8 +27,17 @@ int NodeGraphEngine::addNode(const std::string &label, SignalNode *signal_node, 
 void NodeGraphEngine::removeNode(int node_id) {
     auto it = std::find_if(m_nodes.begin(), m_nodes.end(),
                            [node_id](const GraphNode &n) { return n.node_id == node_id; });
+    if (it != m_nodes.end())
+        removeNodeForSignalNode(it->signal_node);
+}
+
+void NodeGraphEngine::removeNodeForSignalNode(SignalNode *signal_node) {
+    auto it = std::find_if(
+        m_nodes.begin(), m_nodes.end(),
+        [signal_node](const GraphNode &n) { return n.signal_node == signal_node; });
     if (it == m_nodes.end())
         return;
+    const int node_id = it->node_id;
 
     LOG_INFO("Removed node '%s' (id=%d)", it->label.c_str(), node_id);
 

--- a/node_graph/src/node_graph_widget.cpp
+++ b/node_graph/src/node_graph_widget.cpp
@@ -558,9 +558,3 @@ void NodeGraphWidget::setupDarkTheme() {
     ImNodes::PushColorStyle(ImNodesCol_Pin, IM_COL32(200, 200, 220, 255));
     ImNodes::PushColorStyle(ImNodesCol_PinHovered, IM_COL32(120, 200, 255, 255));
 }
-
-size_t NodeGraphWidget::findNodeIndex(int node_id) const {
-    (void)node_id;
-    // Real implementation is added in a later task.
-    return size_t(-1);
-}

--- a/pfb_channelizer/include/pfb_channelizer_engine.h
+++ b/pfb_channelizer/include/pfb_channelizer_engine.h
@@ -5,9 +5,9 @@
 #include "pfb_filter_design.h"
 #include "signal_node.h"
 #include "spectrum.h"
+#include <cstdint>
 #include <string>
 #include <vector>
-
 struct PFBChannel {
     int channel_index;
     double center_freq_Hz;
@@ -78,10 +78,21 @@ class PFBChannelizerEngine : public ComponentEngineBase {
     void deserialize(const nlohmann::json &) override;
 
   private:
+    struct ToneIndexSlot {
+        double freq_Hz = 0.0;
+        size_t output_index = 0;
+        uint64_t generation = 0;
+        bool occupied = false;
+    };
+
     PFBConfig m_cfg;
     int m_active_channel = 0;
     std::vector<PFBChannel> m_channels;
     std::vector<double> m_cached_freqs;
+    std::vector<int> m_overlap_counts;
+    std::vector<ToneIndexSlot> m_tone_index;
+    size_t m_tone_index_mask = 0;
+    uint64_t m_tone_index_generation = 0;
     double m_cached_Fs_Hz = 0;
     int m_cached_K = 0;
     int m_cached_sampling_ratio = 0;
@@ -89,6 +100,8 @@ class PFBChannelizerEngine : public ComponentEngineBase {
     bool m_fs_from_input = false;
 
     void recomputeChannels(const std::vector<double> &freqs);
+    void prepareToneIndex(size_t expected_tones);
+    ToneIndexSlot &toneIndexSlot(double freq_Hz);
     // Shared real prototype; rebuilt whenever M/K/beta change. The single
     // source of truth for channel weights (also used by the Filter Calculator).
     PfbFilterDesign m_design{32, 8, 8.0};

--- a/pfb_channelizer/src/pfb_channelizer_engine.cpp
+++ b/pfb_channelizer/src/pfb_channelizer_engine.cpp
@@ -2,10 +2,49 @@
 #include "pfb_channelizer_engine.h"
 #include <algorithm>
 #include <cmath>
+#include <functional>
+#include <limits>
 #include <nlohmann/json.hpp>
+#include <stdexcept>
 
 PFBChannelizerEngine::PFBChannelizerEngine(int id, NodeGraphEngine &graph)
     : ComponentEngineBase(id, graph, "PFB", 1, 2) {}
+
+void PFBChannelizerEngine::prepareToneIndex(size_t expected_tones) {
+    constexpr size_t min_capacity = 8;
+    if (expected_tones == 0)
+        return;
+    if (expected_tones > std::numeric_limits<size_t>::max() / 2)
+        throw std::length_error("PFB tone index size overflow");
+
+    const size_t required = std::max(min_capacity, expected_tones * 2);
+    size_t capacity = min_capacity;
+    while (capacity < required) {
+        if (capacity > std::numeric_limits<size_t>::max() / 2)
+            throw std::length_error("PFB tone index size overflow");
+        capacity *= 2;
+    }
+    if (m_tone_index.size() >= capacity)
+        return;
+
+    m_tone_index.assign(capacity, {});
+    m_tone_index_mask = capacity - 1;
+    m_tone_index_generation = 0;
+}
+
+PFBChannelizerEngine::ToneIndexSlot &
+PFBChannelizerEngine::toneIndexSlot(double freq_Hz) {
+    const size_t start = std::hash<double>{}(freq_Hz) & m_tone_index_mask;
+    for (size_t offset = 0; offset < m_tone_index.size(); ++offset) {
+        const size_t index = (start + offset) & m_tone_index_mask;
+        auto &slot = m_tone_index[index];
+        if (!slot.occupied || slot.generation != m_tone_index_generation)
+            return slot;
+        if (slot.freq_Hz == freq_Hz)
+            return slot;
+    }
+    throw std::logic_error("PFB tone index is full");
+}
 
 int PFBChannelizerEngine::outputPinId(int index) const {
     if (!m_graph || m_graph_node_id < 0)
@@ -117,6 +156,7 @@ void PFBChannelizerEngine::update(double) {
         out_full.phase_deg.clear();
         out_full.fs_Hz = m_cfg.Fs_Hz;
         out_full.is_complex_baseband = in_ptr ? in_ptr->is_complex_baseband : false;
+        m_overlap_counts.clear();
         out_full.bumpGeneration();
         return;
     }
@@ -209,7 +249,7 @@ void PFBChannelizerEngine::update(double) {
     out_full.noise_W.assign(n_full, 0.0);
     out_full.noise_total_W.assign(n_full, 0.0);
     out_full.noise_added_W.assign(n_full, 0.0);
-    std::vector<int> overlap_count(n_full, 0);
+    m_overlap_counts.assign(n_full, 0);
     // Accumulate PSD (W/Hz), not per-bin power. Each channel's noise density
     // is total channel noise power divided by the channel bandwidth, then
     // averaged across overlapping channels to produce a flat combined band.
@@ -219,14 +259,14 @@ void PFBChannelizerEngine::update(double) {
             if (bin_idx >= 0 && bin_idx < static_cast<int>(n_full)) {
                 out_full.noise_W[bin_idx] += density;
                 out_full.noise_total_W[bin_idx] += density;
-                ++overlap_count[bin_idx];
+                ++m_overlap_counts[bin_idx];
             }
         }
     }
     for (size_t i = 0; i < n_full; ++i) {
-        if (overlap_count[i] > 1) {
-            out_full.noise_W[i] /= static_cast<double>(overlap_count[i]);
-            out_full.noise_total_W[i] /= static_cast<double>(overlap_count[i]);
+        if (m_overlap_counts[i] > 1) {
+            out_full.noise_W[i] /= static_cast<double>(m_overlap_counts[i]);
+            out_full.noise_total_W[i] /= static_cast<double>(m_overlap_counts[i]);
         }
     }
     out_full.phase_deg = in_ptr->phase_deg;
@@ -234,27 +274,31 @@ void PFBChannelizerEngine::update(double) {
     // Each input tone should appear once in the full-band output. Overlapping
     // channel filters produce multiple representations of the same tone; keep
     // the strongest filtered representation rather than exposing duplicates.
-    // A channel only sees tones within +/-channel_bw of its centre. Search
-    // only the recent channel runs that can overlap the current one; this
-    // keeps duplicate suppression bounded while supporting oversampling.
+    // A reusable frequency index preserves first-appearance ordering while
+    // avoiding a scan through all previously emitted tones.
     out_full.tones.clear();
-    const size_t overlap_channels = static_cast<size_t>(2 * m_cfg.sampling_ratio);
-    std::vector<size_t> run_starts(m_channels.size(), 0);
-    for (size_t k = 0; k < m_channels.size(); ++k) {
-        const auto &ch = m_channels[k];
-        const size_t run_start = out_full.tones.size();
-        run_starts[k] = run_start;
-        const size_t window_begin = (k >= overlap_channels) ? run_starts[k - overlap_channels] : 0;
+    prepareToneIndex(in_ptr->tones.size());
+    if (++m_tone_index_generation == 0) {
+        for (auto &slot : m_tone_index)
+            slot = {};
+        m_tone_index_generation = 1;
+    }
+    for (const auto &ch : m_channels) {
         for (const auto &tone : ch.tones) {
-            auto existing =
-                std::find_if(out_full.tones.begin() + static_cast<std::ptrdiff_t>(window_begin),
-                             out_full.tones.end(), [&tone](const Spectrum::Tone &candidate) {
-                                 return candidate.freq_Hz == tone.freq_Hz;
-                             });
-            if (existing == out_full.tones.end())
+            if (std::isnan(tone.freq_Hz)) {
                 out_full.tones.push_back(tone);
-            else if (tone.power_dBm > existing->power_dBm)
-                *existing = tone;
+                continue;
+            }
+            auto &slot = toneIndexSlot(tone.freq_Hz);
+            if (!slot.occupied || slot.generation != m_tone_index_generation) {
+                slot.freq_Hz = tone.freq_Hz;
+                slot.output_index = out_full.tones.size();
+                slot.generation = m_tone_index_generation;
+                slot.occupied = true;
+                out_full.tones.push_back(tone);
+            } else if (tone.power_dBm > out_full.tones[slot.output_index].power_dBm) {
+                out_full.tones[slot.output_index] = tone;
+            }
         }
     }
 

--- a/pfb_channelizer/src/pfb_channelizer_engine.cpp
+++ b/pfb_channelizer/src/pfb_channelizer_engine.cpp
@@ -32,9 +32,8 @@ void PFBChannelizerEngine::prepareToneIndex(size_t expected_tones) {
     m_tone_index_generation = 0;
 }
 
-PFBChannelizerEngine::ToneIndexSlot &
-PFBChannelizerEngine::toneIndexSlot(double freq_Hz) {
-    const size_t start = std::hash<double>{}(freq_Hz) & m_tone_index_mask;
+PFBChannelizerEngine::ToneIndexSlot &PFBChannelizerEngine::toneIndexSlot(double freq_Hz) {
+    const size_t start = std::hash<double>{}(freq_Hz)&m_tone_index_mask;
     for (size_t offset = 0; offset < m_tone_index.size(); ++offset) {
         const size_t index = (start + offset) & m_tone_index_mask;
         auto &slot = m_tone_index[index];

--- a/tests/test_node_graph_engine.cpp
+++ b/tests/test_node_graph_engine.cpp
@@ -8,15 +8,47 @@ TEST_CASE("NodeGraphEngine can add and remove nodes", "[node_graph]") {
     SignalNode node1;
     SignalNode node2;
 
-    int id1 = engine.addNode("Generator 0", &node1, false, true);
-    int id2 = engine.addNode("Amplifier 0", &node2, true, true);
+    const int id1 = engine.addNode("Generator 0", &node1, false, true);
+    engine.addNode("Amplifier 0", &node2, true, true);
 
     REQUIRE(engine.nodes().size() == 2);
     REQUIRE(engine.nodes()[0].label == "Generator 0");
     REQUIRE(engine.nodes()[1].label == "Amplifier 0");
 
-    engine.removeNode(id1);
-    REQUIRE(engine.nodes().size() == 1);
+    SECTION("removes the first node by its ID") {
+        engine.removeNode(id1);
+        REQUIRE(engine.nodes().size() == 1);
+    }
+
+    SECTION("removes the requested ID when signal nodes are shared") {
+        NodeGraphEngine shared_engine;
+        SignalNode shared_node;
+        SignalNode sink_node;
+
+        const int first_id = shared_engine.addNode("First", &shared_node, 0, 1);
+        const int second_id = shared_engine.addNode("Second", &shared_node, 0, 1);
+        const int sink_id = shared_engine.addNode("Sink", &sink_node, 1, 0);
+        const int first_output = shared_engine.nodes()[0].output_pin_ids[0];
+        const int second_output = shared_engine.nodes()[1].output_pin_ids[0];
+        const int sink_input = shared_engine.nodes()[2].input_pin_ids[0];
+
+        const int first_link = shared_engine.addLink(first_output, sink_input);
+        const int second_link = shared_engine.addLink(second_output, sink_input);
+        REQUIRE(shared_engine.addProbePin(first_output));
+        REQUIRE(shared_engine.addProbePin(second_output));
+
+        shared_engine.removeNode(second_id);
+
+        REQUIRE(shared_engine.nodes().size() == 2);
+        REQUIRE(shared_engine.nodes()[0].node_id == first_id);
+        REQUIRE(shared_engine.nodes()[1].node_id == sink_id);
+        REQUIRE(shared_engine.links().size() == 1);
+        REQUIRE(shared_engine.links()[0].link_id == first_link);
+        REQUIRE(shared_engine.links()[0].start_pin_id == first_output);
+        REQUIRE(shared_engine.links()[0].link_id != second_link);
+        REQUIRE(shared_engine.probePins().size() == 1);
+        REQUIRE(shared_engine.probePins()[0] == first_output);
+    }
 }
 
 TEST_CASE("NodeGraphEngine can link nodes and query topology", "[node_graph]") {

--- a/tests/test_pfb_filter_design.cpp
+++ b/tests/test_pfb_filter_design.cpp
@@ -244,3 +244,28 @@ TEST_CASE("PFB full-band output deduplicates late in the channel sweep", "[pfb_f
     for (size_t i = 1; i < freqs.size(); ++i)
         REQUIRE(freqs[i] > freqs[i - 1]); // strictly increasing => globally unique
 }
+
+TEST_CASE("PFB tone index handles disjoint generations without saturation",
+          "[pfb_filter_design][performance]") {
+    NodeGraphEngine graph;
+    PFBChannelizerEngine pfb(0, graph);
+    pfb.setChannelCount(8);
+    pfb.setFs_Hz(200e6);
+
+    Spectrum in;
+    in.frequencies.resize(401);
+    for (int i = 0; i < 401; ++i)
+        in.frequencies[i] = -100e6 + i * 0.5e6;
+    in.noise_total_W.assign(in.frequencies.size(), 1e-20);
+    pfb.node().inputs[0] = &in;
+
+    for (int generation = 0; generation < 3; ++generation) {
+        in.tones.clear();
+        for (int i = 0; i < 8; ++i)
+            in.tones.push_back({-87e6 + i * 25e6 + generation * 0.25e6, -30.0, 0.0});
+        in.bumpGeneration();
+        pfb.update(0.0);
+
+        REQUIRE(pfb.node().outputs[1].tones.size() == in.tones.size());
+    }
+}

--- a/tests/test_pfb_filter_design.cpp
+++ b/tests/test_pfb_filter_design.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <vector>
 


### PR DESCRIPTION
## Summary

Closes #82.

- Preserve the existing generator source-vs-added noise invariant and regression coverage already present on master.
- Replace per-frame function/map dispatch with an O(1) ComponentRegistry graph-node index while preserving topological update order.
- Replace quadratic PFB tone scans with reusable generation-stamped open-addressed indexing and reuse overlap scratch storage.
- Add a three-generation disjoint-frequency saturation regression.
- Remove the unreachable NodeGraphWidget stub and add exact-signal-node rollback support for duplicate graph IDs.

## Verification

- `cmake --build build`
- `ctest --test-dir build --output-on-failure` — 250/250 passed
- Registry tag run — 25 assertions in 6 test cases passed
- CRLF-aware `git diff --check` passed

Superpowers planning documents remain ignored and uncommitted.