### PR TITLE
chore: prepare v0.22.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.22.2] - 2026-09-08
+
+### Changed
+
+- **Release pipeline** — releases are now prepared through a `release/vX.Y.Z` pull request and tagged only after merge; the pull-request CI pipeline was replaced by tag-time validation (format check and AddressSanitizer on every release tag, plus a Linux GCC Debug full-test-suite leg for patch releases).
+
 ## [0.22.1] - 2026-09-08
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.20)
 
-project (RfSimulator VERSION 0.22.1)
+project (RfSimulator VERSION 0.22.2)
 
 # FetchContent'd dependencies below call their own project() commands, which
 # resets PROJECT_VERSION (and _MAJOR/_MINOR/_PATCH) for the remainder of this


### PR DESCRIPTION
## Summary

Release preparation for v0.22.2 (first release through the new PR-before-tag pipeline): bumps `CMakeLists.txt` to 0.22.2 and adds the matching `CHANGELOG.md` section covering the release-workflow consolidation from PR #94.

## Related issue

N/A — tests the new release process end-to-end.

## Type of change

- [x] Build / CI

## Test plan

- [x] `cmake -B build -G Ninja && cmake --build build` — 32/32 targets (incremental, version-def rebuild)
- [x] `ctest --test-dir build --output-on-failure -E Benchmark` — 244/244 passed
- [x] Tag-time validation mirror: tag `0.22.2` == CMake version == changelog section
- [ ] Post-merge: push annotated `v0.22.2` on the merged master commit and confirm `release.yml` runs `format`, `sanitizer`, `patch-test`, `package`, then the draft release

## Checklist

- [x] No C++ source changes (docs + version bump only); format checks not applicable
- [x] Existing tests still pass
