### PR TITLE
docs: dep-browsing path for fresh factory worktrees (AGENTS.md + CONTRIBUTING)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ Default section order:
 - PFB channelizers default to critical sampling (1x) and support a persisted 2x oversampling ratio; channel output `fs_Hz` is `ratio * input Fs / M`, with channel centers unchanged and usable channel bandwidth scaled by the ratio.
 - When the user requests a durable behavior change, record it here or in the relevant child AGENTS.md
 - Superpowers plan/spec documents are working materials and must not be committed.
+- Never run filesystem-wide searches (`find /`, `dir /s`, global greps from the drive root) — they hang headless agent runs past their watchdog. In a fresh factory worktree there is no local `build/`; dependency *sources* are browsable at `../../build/_deps/<name>-src` relative to the worktree (canonical checkout), and a fresh checkout can configure deps itself with `cmake -B build -G Ninja` (~90 s). Read `CMakeLists.txt` `FetchContent_Declare` pins for versions.
 
 ## Release Contract
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ cmake --build build
 
 The first build takes 60-90s while FetchContent clones dependencies. Subsequent builds are fast.
 
-**Where dependency sources live:** all FetchContent dependencies (imgui, implot, catch2, imgui_test_engine, …) are fetched into `build/_deps/<name>-src/` inside the active build directory. Never search the filesystem for headers like `imgui_internal.h` — on Windows a `find /`-style scan hangs far past any agent timeout. Read `build/_deps/*-src` or the `FetchContent_Declare` block in `CMakeLists.txt` instead.
+**Where dependency sources live:** all FetchContent dependencies (imgui, implot, catch2, imgui_test_engine, …) are fetched into `build/_deps/<name>-src/` inside the active build directory. A fresh git worktree (e.g. a factory candidate) has **no** `build/` yet — run `cmake -B build -G Ninja` once (~90 s) to fetch them there, or browse the canonical checkout's copy (`../../build/_deps/<name>-src` from a worktree under `.archon/…/worktrees/`). Never search the filesystem for headers like `imgui_internal.h` — a `find /`-style scan hangs far past any agent timeout on Windows. Read `CMakeLists.txt`'s `FetchContent_Declare` block for pinned versions.
 
 **One-time setup — enable the format pre-commit hook** (blocks commits that would fail the release workflow's `format` job):
 


### PR DESCRIPTION
Attempt-3 investigate agent ran `find /` despite the earlier note because `build/_deps` does not exist in a fresh candidate worktree. Records the structural path (../../build/_deps from the worktree), the ~90s cmake configure alternative, and a durable AGENTS.md prohibition on fs-wide scans (auto-loaded by pi).