### PR TITLE
chore: prepare v0.22.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [0.22.3] - 2026-09-10
+
+### Security
+
+- **Extension trust gate** — project-local extensions must now be explicitly trusted before they run. Approvals persist per canonical extension root in `<exe_dir>/extension_trust.json`, fail closed on every degraded path, and keep trust and run as separate user actions; untrusted tools are absent from the Tools menu and gain `Trust...`/`Revoke trust` controls in the Extensions panel.
+- **Duplicate extension IDs** — a project-local extension can no longer silently override a built-in or global extension with the same ID. The first root in scan order wins and the loser is reported as `Shadowed` instead of taking effect.
+
+### Changed
+
+- **Behavior change for existing users** — a project-local tool that ran before now needs one **Trust...** click, and a project-local extension that previously overrode a built-in or global ID stops working (by design).
+
+### Documentation
+
+- Point agent guidance at `build/_deps` for dependency sources and forbid filesystem-wide header searches.
+
 ## [0.22.2] - 2026-09-08
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.20)
 
-project (RfSimulator VERSION 0.22.2)
+project (RfSimulator VERSION 0.22.3)
 
 # FetchContent'd dependencies below call their own project() commands, which
 # resets PROJECT_VERSION (and _MAJOR/_MINOR/_PATCH) for the remainder of this


### PR DESCRIPTION
## Summary

Release preparation for v0.22.3: bumps `CMakeLists.txt` to 0.22.3 and adds the matching `CHANGELOG.md` section covering the extension trust gate (#99) and the agent dependency-browsing guidance (#97, #98). Only version metadata and the changelog change in this PR.

## Related issue

N/A — release preparation.

## Type of change

- [x] Build / CI

## Test plan

- [x] `clang-format 18.1.8 --dry-run --Werror` across all 165 CI-scanned source files — clean
- [x] `cmake --build build` — exit 0
- [x] `ctest --test-dir build --output-on-failure` — 253/253 passed
- [ ] Post-merge: push annotated `v0.22.3` on the merged master commit and confirm the release workflow succeeds

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran `clang-format -i` on changed files (no C++ files changed)
- [x] I added or updated tests where appropriate
- [x] Existing tests still pass