### PR TITLE
fix: give the extension-trust symlink test an ImGui context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - Point agent guidance at `build/_deps` for dependency sources and forbid filesystem-wide header searches.
 
+### Testing
+
+- Initialize the ImGui context in the extension-trust symlink case so it exercises the project-local trust gate instead of crashing the Linux test legs.
+
 ## [0.22.2] - 2026-09-08
 
 ### Changed

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -33,7 +33,7 @@ Own the Catch2 v3.4.0 unit test suite and ImGui test engine UI tests. Verify all
 - Test both nominal and edge cases: zero inputs, max values, parameter extremes
 - Node graph tests must verify probe routing, link topology, and topological sort
 - Touchstone parser tests must cover all format variants (DB, MA, RI) and frequency units
-- Do not depend on ImGui or GLFW in pure DSP-engine tests; app-integration tests may create ImGui, ImPlot, and ImNodes contexts to construct `RfSimulatorApp` safely
+- Do not depend on ImGui or GLFW in pure DSP-engine tests; app-integration tests **must** create ImGui, ImPlot, and ImNodes contexts (`TEST_CASE_METHOD(ImGuiFixture, ...)`) before constructing `RfSimulatorApp`, which otherwise segfaults headlessly on the Linux/ASan legs.
 - App-level tests may include `simulator::app` for integration scenarios
 
 ## Verification

--- a/tests/test_issue45_extension_trust.cpp
+++ b/tests/test_issue45_extension_trust.cpp
@@ -705,8 +705,8 @@ TEST_CASE("extension manager flags a duplicate external-tool id as shadowed",
             fs::weakly_canonical(builtin_root / "bin" / "builtin.py"));
 }
 
-TEST_CASE("a symlinked extension under the project root stays project-local",
-          "[issue45][discovery][symlink]") {
+TEST_CASE_METHOD(ImGuiFixture, "a symlinked extension under the project root stays project-local",
+                 "[issue45][discovery][symlink]") {
     const fs::path base = fs::temp_directory_path() / "rfsim_ext45_symlink";
     const fs::path ext_root = base / "rf-sim-extensions";
     const fs::path outside = base / "payload-outside";


### PR DESCRIPTION
## Summary

Fixes the `test_issue45_extension_trust` segfault that failed the v0.22.3 release gate on both the Linux GCC 14 Debug and AddressSanitizer legs. The symlink case was the only app-constructing test written as a plain `TEST_CASE`; it built an `RfSimulatorApp` with no ImGui/ImNodes context, so `ImNodes::EditorContextSet` wrote through a null context. Windows CI never caught it because directory symlinks are unavailable there, so the case SKIPs before reaching the app construction.

## Related issue

N/A - restores the v0.22.3 release gate.

## Type of change

- [x] Bug fix

## Test plan

- [x] Red: temporary probe constructing `RfSimulatorApp` under the plain `TEST_CASE` killed the process (exit 5, no output)
- [x] Green: same probe under `TEST_CASE_METHOD(ImGuiFixture, ...)` constructs fine and the case proceeds to its symlink SKIP
- [x] `clang-format 18.1.8 --dry-run --Werror tests/test_issue45_extension_trust.cpp` - clean
- [x] `cmake --build build` - exit 0
- [x] `build/bin/test_issue45_extension_trust.exe` - 138/138 assertions passed (20 cases: 19 passed, 1 skipped)
- [x] `ctest --test-dir build --output-on-failure` - 253/253 passed
- [ ] Tag-time re-run: move `v0.22.3` to the merged master commit and confirm the release workflow succeeds

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran `clang-format -i` on changed files
- [x] I added or updated tests where appropriate
- [x] Existing tests still pass