### PR TITLE
chore: prepare v0.22.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.22.4] - 2026-09-10
+
+### Fixed
+
+- **Spectrum Analyzer sizing** — the plot now fills the panel's remaining height instead of sitting at ImPlot's fixed 300 px default, keeps a 180 px usable floor, and reserves the readout rows drawn below it (including the marker block while the marker is enabled). The window's minimum height drops from 400 px to 240 px, so a docked analyzer no longer forces its dock node to grow into neighbouring panels.
+
+### Testing
+
+- Add a UI regression test that reads the analyzer plot rect to verify it tracks the window size, respects the floor, yields room to the marker controls, and survives close/reopen.
+
 ## [0.22.3] - 2026-09-10
 
 ### Security

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.20)
 
-project (RfSimulator VERSION 0.22.3)
+project (RfSimulator VERSION 0.22.4)
 
 # FetchContent'd dependencies below call their own project() commands, which
 # resets PROJECT_VERSION (and _MAJOR/_MINOR/_PATCH) for the remainder of this


### PR DESCRIPTION
## Summary

Release preparation for v0.22.4: bumps `CMakeLists.txt` to 0.22.4 and adds the matching `CHANGELOG.md` section covering the Spectrum Analyzer sizing fix (#103, closes #88). Only version metadata and the changelog change in this PR.

## Related issue

N/A — release preparation.

## Type of change

- [x] Build / CI

## Test plan

- [x] `cmake --build build` — exit 0 (54 targets, `-DAPP_VERSION="0.22.4"` and `-DAPP_GIT_HASH="20bd3c7"` confirmed in `compile_commands.json`)
- [x] `ctest --test-dir build --output-on-failure` — 253/253 passed
- [x] `clang-format 18.1.8 --dry-run --Werror` across all 165 CI-scanned source files — clean
- [ ] Post-merge: push annotated `v0.22.4` on the merged master commit and confirm the release workflow succeeds

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran `clang-format -i` on changed files (no C++ files changed)
- [x] I added or updated tests where appropriate
- [x] Existing tests still pass
