### PR TITLE
Fix issue #87 flow validation and recovery

### DIFF
--- a/node_graph/AGENTS.md
+++ b/node_graph/AGENTS.md
@@ -26,6 +26,8 @@ interaction, schematic symbols), and `rewireComponentInputs()`.
 - Groups (`Group`, `GroupBoundaryPin` from `common/include/group.h`) are a visual layer: `NodeGraphEngine` owns them and `NodeGraphWidget` renders/collapses them; no DSP engine consumes them.
 - Node, pin, link, group, and boundary-pin id counters are monotonic and restored on project load through `setNextIds()`, `setNextGroupId()`, and `setNextBoundaryPinId()`.
 - Node removal must re-run `rewireComponentInputs()` synchronously with `ComponentRegistry::remove()` so no surviving component holds a dangling `Spectrum*` into the destroyed engine's `SignalNode` (issue #37).
+- `topologicalOrder()` counts only links whose start and end pins both resolve to graph nodes;
+  stale or dangling links are not treated as graph edges or cycles.
 - Widget callbacks (`onNodeMoved`, `onRemoveNode`, `onDuplicateNode`, `onLinkChanged`, `onLinkCreating`, `onNodeHover`) are the only channel from widget to app; the engine itself takes no app-level callbacks.
 
 ## Work Guidance

--- a/node_graph/src/node_graph_engine.cpp
+++ b/node_graph/src/node_graph_engine.cpp
@@ -289,9 +289,10 @@ std::vector<int> NodeGraphEngine::topologicalOrder() const {
     }
 
     for (const auto &link : m_links) {
-        auto it = pin_owner.find(link.end_pin_id);
-        if (it != pin_owner.end())
-            in_degree[it->second]++;
+        const auto start_it = pin_owner.find(link.start_pin_id);
+        const auto end_it = pin_owner.find(link.end_pin_id);
+        if (start_it != pin_owner.end() && end_it != pin_owner.end())
+            in_degree[end_it->second]++;
     }
 
     std::queue<int> q;

--- a/test_flow/AGENTS.md
+++ b/test_flow/AGENTS.md
@@ -36,6 +36,8 @@ component output ports.
   failure.
 - A fatal flow error yields `ok = false` with zero rows, and the loaded spec is reset — a failed load
   never leaks partially parsed conditions.
+- `RunFlow()` converts component `deserialize()` exceptions into `DeserializeFailed`, attempts to restore
+  targeted baseline snapshots, reports rollback failure details, and returns no rows.
 - `test_flow` is one of the mirrored format-check directory lists in `scripts/format.sh`,
   `.githooks/pre-commit`, and `.github/workflows/release.yml`; keep all three in lockstep when
   directories are added or removed.

--- a/test_flow/include/flow_types.h
+++ b/test_flow/include/flow_types.h
@@ -21,6 +21,7 @@ enum class FlowErrorCode {
     DuplicateConditionTarget,
     DuplicateMeasurement,
     CyclicGraph,
+    DeserializeFailed,
 };
 
 inline const char *flowErrorCodeName(FlowErrorCode code) {
@@ -53,6 +54,8 @@ inline const char *flowErrorCodeName(FlowErrorCode code) {
         return "duplicate_measurement";
     case FlowErrorCode::CyclicGraph:
         return "cyclic_graph";
+    case FlowErrorCode::DeserializeFailed:
+        return "deserialize_failed";
     }
     return "unknown";
 }

--- a/test_flow/src/flow_metrics.cpp
+++ b/test_flow/src/flow_metrics.cpp
@@ -6,8 +6,29 @@
 #include <limits>
 
 namespace {
+constexpr double kFrequencyTolerance = 1e-12;
 
 double nan() { return std::numeric_limits<double>::quiet_NaN(); }
+
+bool nearlyEqual(double left, double right) {
+    const double scale = std::max({1.0, std::abs(left), std::abs(right)});
+    return std::abs(left - right) <= kFrequencyTolerance * scale;
+}
+
+bool validFrequencyGrid(const std::vector<double> &frequencies) {
+    if (frequencies.size() < 2)
+        return false;
+    const double bin_width = frequencies[1] - frequencies[0];
+    if (!std::isfinite(bin_width) || bin_width <= 0.0)
+        return false;
+    for (size_t i = 0; i < frequencies.size(); ++i) {
+        if (!std::isfinite(frequencies[i]) || (i > 0 && frequencies[i] <= frequencies[i - 1]))
+            return false;
+        if (i > 1 && !nearlyEqual(frequencies[i] - frequencies[i - 1], bin_width))
+            return false;
+    }
+    return true;
+}
 
 // Total power in dBm — the same measurement the GUI power meter reports.
 double totalPower_dBm(const Spectrum &spec) {
@@ -18,6 +39,9 @@ double totalPower_dBm(const Spectrum &spec) {
 const Spectrum::Tone *strongestTone(const Spectrum &spec) {
     const Spectrum::Tone *best = nullptr;
     for (const auto &tone : spec.tones) {
+        if (!std::isfinite(tone.freq_Hz) || !std::isfinite(tone.power_dBm) ||
+            !std::isfinite(tone.phase_deg))
+            return nullptr;
         if (!best || tone.power_dBm > best->power_dBm)
             best = &tone;
     }
@@ -37,12 +61,9 @@ double peakFreq_Hz(const Spectrum &spec) {
 // noise_total_W is a per-Hz density (W/Hz) — PowerMeterEngine integrates it as
 // density * bin_width — so the mean over the grid converts to dBm/Hz directly.
 double noiseFloor_dBm_per_Hz(const Spectrum &spec) {
-    if (spec.frequencies.size() < 2 || spec.noise_total_W.empty())
+    if (!validFrequencyGrid(spec.frequencies))
         return nan();
-    // A density vector that does not match the grid is malformed data. Truncating
-    // would report a plausible value where power_dBm correctly reports
-    // not-computable, so both metrics must agree the input is unmeasurable.
-    if (spec.noise_total_W.size() != spec.frequencies.size())
+    if (!spec.noise_total_W.empty() && spec.noise_total_W.size() != spec.frequencies.size())
         return nan();
 
     double sum = 0.0;
@@ -53,12 +74,16 @@ double noiseFloor_dBm_per_Hz(const Spectrum &spec) {
         if (!std::isfinite(density) || density < 0.0)
             return nan(); // malformed data
         sum += density;
+        if (!std::isfinite(sum))
+            return nan();
     }
-    const double mean_density = sum / static_cast<double>(spec.noise_total_W.size());
 
-    if (mean_density == 0.0)
+    if (sum == 0.0)
         return -std::numeric_limits<double>::infinity(); // well-formed but silent
-    return 10.0 * std::log10(mean_density * 1000.0);     // W/Hz -> dBm/Hz
+    const double mean_density = sum / static_cast<double>(spec.noise_total_W.size());
+    if (!std::isfinite(mean_density))
+        return nan();
+    return 10.0 * (std::log10(mean_density) + 3.0); // W/Hz -> dBm/Hz
 }
 
 } // namespace

--- a/test_flow/src/flow_runner.cpp
+++ b/test_flow/src/flow_runner.cpp
@@ -8,8 +8,12 @@
 #include "signal_node.h"
 
 #include <cmath>
+#include <cstdint>
+#include <exception>
 #include <filesystem>
 #include <fstream>
+#include <limits>
+#include <optional>
 #include <span>
 #include <string>
 #include <unordered_map>
@@ -45,6 +49,22 @@ std::string knownMetricNames() {
     return out;
 }
 
+std::optional<int> checkedJsonInt(const nlohmann::json &value) {
+    if (value.is_number_unsigned()) {
+        const std::uint64_t number = value.get<std::uint64_t>();
+        if (number <= static_cast<std::uint64_t>(std::numeric_limits<int>::max()))
+            return static_cast<int>(number);
+        return std::nullopt;
+    }
+    if (value.is_number_integer()) {
+        const std::int64_t number = value.get<std::int64_t>();
+        if (number >= static_cast<std::int64_t>(std::numeric_limits<int>::min()) &&
+            number <= static_cast<std::int64_t>(std::numeric_limits<int>::max()))
+            return static_cast<int>(number);
+    }
+    return std::nullopt;
+}
+
 } // namespace
 
 FlowLoadResult LoadFlowFile(const std::string &path) {
@@ -75,12 +95,12 @@ FlowLoadResult LoadFlowFile(const std::string &path) {
 
     if (!root.contains("version"))
         return fail(FlowErrorCode::WrongShape, "missing required field 'version'");
-    if (!root["version"].is_number_integer())
-        return fail(FlowErrorCode::BadFieldType, "'version' must be an integer");
-    if (root["version"].get<int>() != 1)
+    const auto version = checkedJsonInt(root["version"]);
+    if (!version)
+        return fail(FlowErrorCode::BadFieldType, "'version' must be a representable integer");
+    if (*version != 1)
         return fail(FlowErrorCode::UnsupportedVersion,
-                    "unsupported flow version " + std::to_string(root["version"].get<int>()) +
-                        " (expected 1)");
+                    "unsupported flow version " + std::to_string(*version) + " (expected 1)");
     out.spec.version = 1;
 
     out.spec.name = std::filesystem::path(path).stem().string();
@@ -101,8 +121,10 @@ FlowLoadResult LoadFlowFile(const std::string &path) {
                 return fail(FlowErrorCode::WrongShape, where + " must be an object");
             if (!cj.contains("component"))
                 return fail(FlowErrorCode::WrongShape, where + " is missing 'component'");
-            if (!cj["component"].is_number_integer())
-                return fail(FlowErrorCode::BadFieldType, where + ".component must be an integer");
+            const auto component_id = checkedJsonInt(cj["component"]);
+            if (!component_id)
+                return fail(FlowErrorCode::BadFieldType,
+                            where + ".component must be a representable integer");
             if (!cj.contains("path"))
                 return fail(FlowErrorCode::WrongShape, where + " is missing 'path'");
             if (!cj["path"].is_string())
@@ -115,7 +137,7 @@ FlowLoadResult LoadFlowFile(const std::string &path) {
                 return fail(FlowErrorCode::WrongShape, where + ".values must not be empty");
 
             Condition condition;
-            condition.component = cj["component"].get<int>();
+            condition.component = *component_id;
             condition.path = cj["path"].get<std::string>();
             for (const auto &vj : cj["values"]) {
                 if (!vj.is_number())
@@ -148,16 +170,20 @@ FlowLoadResult LoadFlowFile(const std::string &path) {
             return fail(FlowErrorCode::WrongShape, where + " must be an object");
         if (!mj.contains("component"))
             return fail(FlowErrorCode::WrongShape, where + " is missing 'component'");
-        if (!mj["component"].is_number_integer())
-            return fail(FlowErrorCode::BadFieldType, where + ".component must be an integer");
+        const auto component_id = checkedJsonInt(mj["component"]);
+        if (!component_id)
+            return fail(FlowErrorCode::BadFieldType,
+                        where + ".component must be a representable integer");
 
         Measurement measurement;
-        measurement.component = mj["component"].get<int>();
+        measurement.component = *component_id;
 
         if (mj.contains("port") && !mj["port"].is_null()) {
-            if (!mj["port"].is_number_integer())
-                return fail(FlowErrorCode::BadFieldType, where + ".port must be an integer");
-            measurement.port = mj["port"].get<int>();
+            const auto port = checkedJsonInt(mj["port"]);
+            if (!port)
+                return fail(FlowErrorCode::BadFieldType,
+                            where + ".port must be a representable integer");
+            measurement.port = *port;
             if (measurement.port < 0)
                 return fail(FlowErrorCode::BadFieldType, where + ".port must not be negative");
         }
@@ -268,6 +294,26 @@ FlowResult RunFlow(const FlowSpec &spec, std::span<IComponentEngine *const> comp
                                engineById(components, condition.component)->serialize());
     }
 
+    const auto restoreBaselines = [&]() -> std::string {
+        std::string rollback_error;
+        for (const auto &baseline : baselines) {
+            try {
+                engineById(components, baseline.first)->deserialize(baseline.second);
+            } catch (const std::exception &e) {
+                if (!rollback_error.empty())
+                    rollback_error += "; ";
+                rollback_error += "component " + std::to_string(baseline.first) + ": " + e.what();
+            } catch (...) {
+                if (!rollback_error.empty())
+                    rollback_error += "; ";
+                rollback_error +=
+                    "component " + std::to_string(baseline.first) + ": unknown exception";
+            }
+        }
+        rewireComponentInputs(components, graph);
+        return rollback_error;
+    };
+
     FlowResult result;
     result.name = spec.name;
 
@@ -295,8 +341,26 @@ FlowResult RunFlow(const FlowSpec &spec, std::span<IComponentEngine *const> comp
             }
             row.conditions.push_back({condition.component, condition.path, value});
         }
-        for (size_t b = 0; b < baselines.size(); ++b)
-            engineById(components, baselines[b].first)->deserialize(working[b]);
+        for (size_t b = 0; b < baselines.size(); ++b) {
+            IComponentEngine *engine = engineById(components, baselines[b].first);
+            try {
+                engine->deserialize(working[b]);
+            } catch (const std::exception &e) {
+                const std::string rollback_error = restoreBaselines();
+                std::string message = "failed to deserialize component " +
+                                      std::to_string(baselines[b].first) + ": " + e.what();
+                if (!rollback_error.empty())
+                    message += " (rollback failed: " + rollback_error + ")";
+                return fail(spec, FlowErrorCode::DeserializeFailed, message);
+            } catch (...) {
+                const std::string rollback_error = restoreBaselines();
+                std::string message = "failed to deserialize component " +
+                                      std::to_string(baselines[b].first) + ": unknown exception";
+                if (!rollback_error.empty())
+                    message += " (rollback failed: " + rollback_error + ")";
+                return fail(spec, FlowErrorCode::DeserializeFailed, message);
+            }
+        }
 
         // Mirrors RfSimulatorApp::rewireInputs() by calling the very same
         // function, so the harness and the GUI can never disagree about a

--- a/tests/test_issue87_flow.cpp
+++ b/tests/test_issue87_flow.cpp
@@ -8,8 +8,6 @@
 #include "node_graph_engine.h"
 #include "pfb_channelizer_engine.h"
 #include "signal_generator_engine.h"
-#include "spectrum.h"
-
 #include <algorithm>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -19,7 +17,42 @@
 #include <limits>
 #include <map>
 #include <nlohmann/json.hpp>
+#include <stdexcept>
 #include <string>
+
+class ThrowingEngine final : public IComponentEngine {
+  public:
+    ThrowingEngine(int id, NodeGraphEngine &graph, bool fail_on_zero = false)
+        : m_id(id), m_fail_on_zero(fail_on_zero), m_graph(&graph) {
+        m_graph_node_id = graph.addNode("Throwing", &m_node, 0, 1);
+        m_node.outputs.resize(1);
+    }
+
+    int id() const override { return m_id; }
+    int graphNodeId() const override { return m_graph_node_id; }
+    int outputPinId() const override { return m_graph->outputPinId(m_graph_node_id); }
+    std::string hoverSummary() const override { return "Throwing"; }
+    SignalNode &node() override { return m_node; }
+    const SignalNode &node() const override { return m_node; }
+    void update(double) override {}
+    std::string_view type_name() const override { return "throwing"; }
+
+    nlohmann::json serialize() const override { return {{"value", m_value}}; }
+    void deserialize(const nlohmann::json &snapshot) override {
+        const double value = snapshot.at("value").get<double>();
+        m_value = value;
+        if (value != 0.0 || (m_fail_on_zero && value == 0.0))
+            throw std::runtime_error("intentional deserialize failure");
+    }
+
+  private:
+    int m_id;
+    int m_graph_node_id = -1;
+    double m_value = 0.0;
+    bool m_fail_on_zero = false;
+    SignalNode m_node;
+    NodeGraphEngine *m_graph = nullptr;
+};
 
 using Catch::Approx;
 
@@ -102,6 +135,60 @@ TEST_CASE("issue87 metrics: peak metrics are not computable without tones", "[is
     const MetricDefinition *power = metric("peak_power_dBm");
     REQUIRE(power != nullptr);
     REQUIRE(std::isnan(power->compute(spec)));
+}
+
+TEST_CASE("issue87 metrics: peak metrics reject non-finite tone fields", "[issue87][metrics]") {
+    Spectrum spec;
+    spec.frequencies = {1e9, 2e9};
+    spec.tones = {{1e9, std::numeric_limits<double>::quiet_NaN(), 0.0}, {2e9, -10.0, 0.0}};
+
+    REQUIRE(std::isnan(metric("peak_power_dBm")->compute(spec)));
+    REQUIRE(std::isnan(metric("peak_freq_Hz")->compute(spec)));
+}
+
+TEST_CASE("issue87 metrics: noise floor rejects malformed frequency grids", "[issue87][metrics]") {
+    Spectrum spec;
+    spec.frequencies = {1e9, 2e9, 4e9};
+    spec.noise_total_W = {4.0e-21, 4.0e-21, 4.0e-21};
+
+    REQUIRE(std::isnan(metric("noise_floor_dBm_per_Hz")->compute(spec)));
+
+    Spectrum repeated;
+    repeated.frequencies = {1e9, 2e9, 2e9};
+    repeated.noise_total_W = {4.0e-21, 4.0e-21, 4.0e-21};
+    REQUIRE(std::isnan(metric("noise_floor_dBm_per_Hz")->compute(repeated)));
+
+    Spectrum nonfinite;
+    nonfinite.frequencies = {1e9, std::numeric_limits<double>::quiet_NaN()};
+    nonfinite.noise_total_W = {4.0e-21, 4.0e-21};
+    REQUIRE(std::isnan(metric("noise_floor_dBm_per_Hz")->compute(nonfinite)));
+}
+
+TEST_CASE("issue87 metrics: empty noise is a valid silent floor", "[issue87][metrics]") {
+    Spectrum spec;
+    spec.frequencies = {1e9, 2e9};
+
+    const double value = metric("noise_floor_dBm_per_Hz")->compute(spec);
+    REQUIRE(std::isinf(value));
+    REQUIRE(value < 0.0);
+}
+
+TEST_CASE("issue87 metrics: noise floor rejects accumulation overflow", "[issue87][metrics]") {
+    Spectrum spec;
+    spec.frequencies = {1e9, 2e9};
+    spec.noise_total_W = {std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
+
+    REQUIRE(std::isnan(metric("noise_floor_dBm_per_Hz")->compute(spec)));
+}
+
+TEST_CASE("issue87 metrics: finite large noise stays finite after dBm conversion",
+          "[issue87][metrics]") {
+    Spectrum spec;
+    spec.frequencies = {1e9, 2e9};
+    const double density = std::numeric_limits<double>::max() / 4.0;
+    spec.noise_total_W = {density, density};
+
+    REQUIRE(std::isfinite(metric("noise_floor_dBm_per_Hz")->compute(spec)));
 }
 
 TEST_CASE("issue87 metrics: noise_floor_dBm_per_Hz is the mean density in dBm/Hz",
@@ -538,6 +625,90 @@ TEST_CASE("issue87 loader: a conditions entry that is not an object is rejected"
             "measure": [{"component": 1, "metric": "power_dBm"}]})"));
     REQUIRE_FALSE(loaded.ok);
     REQUIRE(loaded.error.code == FlowErrorCode::WrongShape);
+}
+
+TEST_CASE("issue87 loader: out-of-range integer fields are rejected", "[issue87][loader]") {
+    const auto bad_version = LoadFlowFile(writeTempFlow(
+        "issue87_version_range.flow.json",
+        R"({"version": 4294967297, "measure": [{"component": 1, "metric": "power_dBm"}]})"));
+
+    const auto bad_negative =
+        LoadFlowFile(writeTempFlow("issue87_negative_component_range.flow.json",
+                                   R"({"version": 1, "measure": [{"component": -2147483649,
+            "metric": "power_dBm"}]})"));
+    REQUIRE_FALSE(bad_negative.ok);
+    REQUIRE(bad_negative.error.code == FlowErrorCode::BadFieldType);
+    REQUIRE_FALSE(bad_version.ok);
+    REQUIRE(bad_version.error.code == FlowErrorCode::BadFieldType);
+
+    const auto bad_component =
+        LoadFlowFile(writeTempFlow("issue87_component_range.flow.json",
+                                   R"({"version": 1, "conditions": [{"component": 4294967296,
+            "path": "gain_dB", "values": [1]}],
+            "measure": [{"component": 1, "metric": "power_dBm"}]})"));
+    REQUIRE_FALSE(bad_component.ok);
+    REQUIRE(bad_component.error.code == FlowErrorCode::BadFieldType);
+
+    const auto bad_port = LoadFlowFile(
+        writeTempFlow("issue87_port_range.flow.json",
+                      R"({"version": 1, "measure": [{"component": 1, "port": 4294967296,
+            "metric": "power_dBm"}]})"));
+    REQUIRE_FALSE(bad_port.ok);
+    REQUIRE(bad_port.error.code == FlowErrorCode::BadFieldType);
+}
+
+TEST_CASE("issue87 runner: dangling links do not create a false cycle", "[issue87][runner]") {
+    NodeGraphEngine graph;
+    AmplifierEngine downstream(101, graph);
+    AmplifierEngine upstream(100, graph);
+    graph.addLink(999, upstream.inputPinId());
+    graph.addLink(upstream.outputPinId(), downstream.inputPinId());
+    std::vector<IComponentEngine *> comps{&downstream, &upstream};
+
+    const auto loaded = LoadFlowFile(
+        writeTempFlow("issue87_dangling_link.flow.json",
+                      R"({"version": 1, "measure": [{"component": 101, "metric": "power_dBm"}]})"));
+    REQUIRE(loaded.ok);
+
+    const FlowResult result = RunFlow(loaded.spec, comps, graph);
+    REQUIRE(result.ok);
+    REQUIRE(result.rows.size() == 1);
+}
+
+TEST_CASE("issue87 runner: deserialize failure is a typed flow error", "[issue87][runner]") {
+    NodeGraphEngine graph;
+    ThrowingEngine engine(300, graph);
+    std::vector<IComponentEngine *> comps{&engine};
+
+    FlowSpec spec;
+    spec.name = "throwing";
+    spec.conditions.push_back(Condition{300, "value", {1.0}});
+    spec.measure.push_back(Measurement{300, 0, "power_dBm"});
+    const nlohmann::json before = engine.serialize();
+
+    FlowResult result;
+    REQUIRE_NOTHROW(result = RunFlow(spec, comps, graph));
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error.code == FlowErrorCode::DeserializeFailed);
+    REQUIRE(result.rows.empty());
+    REQUIRE(engine.serialize() == before);
+}
+
+TEST_CASE("issue87 runner: rollback failure is reported", "[issue87][runner]") {
+    NodeGraphEngine graph;
+    ThrowingEngine engine(301, graph, true);
+    std::vector<IComponentEngine *> comps{&engine};
+
+    FlowSpec spec;
+    spec.name = "rollback-failure";
+    spec.conditions.push_back(Condition{301, "value", {1.0}});
+    spec.measure.push_back(Measurement{301, 0, "power_dBm"});
+
+    const FlowResult result = RunFlow(spec, comps, graph);
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error.code == FlowErrorCode::DeserializeFailed);
+    REQUIRE(result.error.message.find("rollback failed") != std::string::npos);
+    REQUIRE(result.rows.empty());
 }
 
 TEST_CASE("issue87 loader: a conditions entry missing a required field is rejected",


### PR DESCRIPTION
## Summary
Hardens the merged issue #87 test-flow harness against malformed graph links, invalid integer inputs, metric overflow, and deserialize failures.

## Related issue
Closes #87

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI

## Test plan

- [x] `cmake --build build --target test_issue87_flow`
- [x] `ctest --test-dir build -R ^test_issue87_flow$ --output-on-failure`
- [x] `ctest --test-dir build --output-on-failure` — 254/254 passed
- [x] Pinned clang-format 18 dry-run passed for all changed C++ files

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran clang-format on changed files
- [x] I added or updated tests where appropriate
- [x] Existing tests still pass