### PR TITLE
chore: prepare v0.23.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [0.23.0] - 2026-09-11
+
+### Added
+
+- **GUI-free test-flow (ATP) harness** — a new `test_flow` library builds and runs a circuit from a JSON flow file with no GUI or app dependency, sweeping component parameters and capturing measurements.
+  - Conditions address persisted `serialize()` keys, including nested and indexed paths such as `tones[0].power_dBm`, and patch them with type-preserving writes that reject mismatched slots.
+  - Built-in metrics report total `power_dBm`, `peak_power_dBm`, `peak_freq_Hz`, and `noise_floor_dBm_per_Hz` from any component output port.
+  - Results export as one JSON row per condition combination; non-measurable readings encode as `null` with a `valid` flag, and a failed load resets the spec instead of leaking partially parsed conditions.
+  - Ship example flow files under `tests/flows/` plus a standalone `test_issue87_flow` end-to-end executable.
+
+### Changed
+
+- **Shared graph link policy** — move `graphLinkAllowed` out of `app/` into `common/graph_link_policy.h` and extract the per-frame input rewiring into `node_graph`'s `rewireComponentInputs()`, giving the app and tests one shared wiring implementation.
+
+### Documentation
+
+- Document the PFB channelizer's 1x/2x oversampling contract — `outputFs_Hz = ratio · Fs / M` with channel centers unchanged — and state its spectral-only limitation, replacing an incorrect channel-overlap claim.
+
+### Testing
+
+- Correct the PFB critical-sampling expectation and add grid-invariance plus sampling-ratio coverage.
+
 ## [0.22.4] - 2026-09-10
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.20)
 
-project (RfSimulator VERSION 0.22.4)
+project (RfSimulator VERSION 0.23.0)
 
 # FetchContent'd dependencies below call their own project() commands, which
 # resets PROJECT_VERSION (and _MAJOR/_MINOR/_PATCH) for the remainder of this


### PR DESCRIPTION
## Summary

Release preparation for v0.23.0: bumps `CMakeLists.txt` to 0.23.0 and adds the matching `CHANGELOG.md` section covering the GUI-free test-flow (ATP) harness (#105, #106), the shared graph link policy / rewire extraction, and the PFB oversampling documentation and test corrections. Only version metadata and the changelog change in this PR.

## Related issue

N/A — release preparation.

## Type of change

- [x] Build / CI

## Test plan

- [x] `cmake --build build` — exit 0, `-DAPP_VERSION="0.23.0"` and `-DAPP_GIT_HASH="fd5b7e4"` confirmed in `compile_commands.json`
- [x] `ctest --test-dir build --output-on-failure` — 254/254 passed (includes `test_issue87_flow` and `test_ui`)
- [x] clang-format 18.1.8 `--dry-run --Werror` across all 177 CI-scanned source files — clean
- [ ] Post-merge: push annotated `v0.23.0` on the merged master commit and confirm the release workflow passes

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran `clang-format -i` on changed files
- [x] I added or updated tests where appropriate (none required for a metadata-only release prep)
- [x] Existing tests still pass
