### PR TITLE
docs: correct v0.23.0 release note for test-flow harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- **GUI-free test-flow (ATP) harness** — a new `test_flow` library builds and runs a circuit from a JSON flow file with no GUI or app dependency, sweeping component parameters and capturing measurements.
+- **GUI-free test-flow (ATP) harness** — a new `test_flow` library runs a JSON flow file against an already-built circuit with no GUI or app dependency: the flow sweeps persisted component parameters and captures measurements, while the caller supplies the engines and graph.
   - Conditions address persisted `serialize()` keys, including nested and indexed paths such as `tones[0].power_dBm`, and patch them with type-preserving writes that reject mismatched slots.
   - Built-in metrics report total `power_dBm`, `peak_power_dBm`, `peak_freq_Hz`, and `noise_floor_dBm_per_Hz` from any component output port.
   - Results export as one JSON row per condition combination; non-measurable readings encode as `null` with a `valid` flag, and a failed load resets the spec instead of leaking partially parsed conditions.


### PR DESCRIPTION
## Summary

Corrects the v0.23.0 changelog headline for the test-flow (ATP) harness. The `test_flow` library does not build the circuit from the flow file: `RunFlow(const FlowSpec &, std::span<IComponentEngine *const>, NodeGraphEngine &)` executes against an already-built circuit, and the flow file only addresses existing components by id. Docs-only follow-up; the v0.23.0 tag is re-pointed onto this commit so the released notes match the actual API.

## Related issue

N/A — release-note correction.

## Type of change

- [x] Documentation

## Test plan

- [x] Text-only change; no build or test impact
- [x] Verified against `test_flow/include/flow_runner.h` (`RunFlow` takes a `std::span<IComponentEngine *const>` and a `NodeGraphEngine &`) and `tests/test_issue87_flow.cpp`, which builds the engines and links them before calling `RunFlow`

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran `clang-format -i` on changed files
- [x] I added or updated tests where appropriate (none — docs only)
- [x] Existing tests still pass
