### PR TITLE
fix: keep spectrum noise jitter off tone peaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Default section order:
 
 - ADC DDC decimation is configurable as 1/2/4/8 and NCO tuning is stored as a normalized factor of the ADC input sample rate; legacy ADC state defaults to decimation 2 and NCO +0.25×Fs.
 - PFB channelizers default to critical sampling (1x) and support a persisted 2x oversampling ratio; channel output `fs_Hz` is `ratio * input Fs / M`, with channel centers unchanged and usable channel bandwidth scaled by the ratio.
+- Spectrum-display noise jitter is a cosmetic effect on the noise floor only; it must never perturb deterministic signal tones, so tone peaks stay fixed frame to frame.
 - When the user requests a durable behavior change, record it here or in the relevant child AGENTS.md
 - Superpowers plan/spec documents are working materials and must not be committed.
 - Never run filesystem-wide searches (`find /`, `dir /s`, global greps from the drive root) — they hang headless agent runs past their watchdog. A fresh git worktree has no local `build/`; dependency *sources* are browsable in the canonical checkout's `build/_deps/<name>-src`, and a fresh checkout can configure deps itself with `cmake -B build -G Ninja` (~90 s). Read `CMakeLists.txt` `FetchContent_Declare` pins for versions.

--- a/spectrum_analyzer/include/spectrum_analyzer_engine.h
+++ b/spectrum_analyzer/include/spectrum_analyzer_engine.h
@@ -57,7 +57,16 @@ class SpectrumAnalyzerEngine {
     double m_vbw = DEFAULT_VBW;
     double m_rbw = DEFAULT_RBW;
 
-    std::vector<double> integratePowerPerBin(const Spectrum &spec) const;
+    // Splits a spectrum into per-bin noise power (W) and per-bin tone impulse
+    // power (W) on its own frequency grid. Both are linear in power, so callers
+    // may filter or jitter them independently before recombining.
+    void binPowerComponents(const Spectrum &spec, std::vector<double> &noise_W,
+                            std::vector<double> &tone_W) const;
+    // Combines RBW-filtered per-bin noise and tone power (W) into a dBm display
+    // trace. The cosmetic noise-floor jitter scales only the noise component, so
+    // deterministic tone peaks never wander; a non-positive sigma disables it.
+    std::vector<double> toJitteredPower_dBm(const std::vector<double> &noise_W,
+                                            const std::vector<double> &tone_W) const;
     std::vector<double> applyTraceMode(const Spectrum &spec,
                                        const std::vector<double> &after_vbw) const;
 
@@ -67,7 +76,8 @@ class SpectrumAnalyzerEngine {
     mutable uint64_t m_cache_spec_gen = 0;
     mutable double m_cache_rbw = 0;
     mutable double m_cache_bin_width = 0;
-    mutable std::vector<double> m_cache_rbw_power_W;
+    mutable std::vector<double> m_cache_rbw_noise_W;
+    mutable std::vector<double> m_cache_rbw_tone_W;
 
     mutable std::mt19937 m_rng;
     mutable bool m_noise_jitter_enabled = true;

--- a/spectrum_analyzer/src/spectrum_analyzer_engine.cpp
+++ b/spectrum_analyzer/src/spectrum_analyzer_engine.cpp
@@ -16,9 +16,11 @@ static double W_to_dBm(double w) {
     return 10.0 * std::log10(w) + 30.0;
 }
 
-std::vector<double> SpectrumAnalyzerEngine::integratePowerPerBin(const Spectrum &spec) const {
+void SpectrumAnalyzerEngine::binPowerComponents(const Spectrum &spec, std::vector<double> &noise_W,
+                                                std::vector<double> &tone_W) const {
     size_t n = spec.frequencies.size();
-    std::vector<double> power_W(n, 0.0);
+    noise_W.assign(n, 0.0);
+    tone_W.assign(n, 0.0);
 
     double bin_width = 1.0;
     if (spec.frequencies.size() >= 2) {
@@ -28,15 +30,15 @@ std::vector<double> SpectrumAnalyzerEngine::integratePowerPerBin(const Spectrum 
     // Convert noise density (W/Hz) to per-bin power (W)
     if (spec.noise_total_W.size() == n) {
         for (size_t i = 0; i < n; ++i) {
-            power_W[i] = spec.noise_total_W[i] * bin_width;
+            noise_W[i] = spec.noise_total_W[i] * bin_width;
         }
     } else if (!spec.noise_total_W.empty()) {
         for (size_t i = 0; i < n && i < spec.noise_total_W.size(); ++i) {
-            power_W[i] = spec.noise_total_W[i] * bin_width;
+            noise_W[i] = spec.noise_total_W[i] * bin_width;
         }
     }
 
-    // Add tones as discrete impulses. Real-domain spectra (pre-ADC) get expanded into their
+    // Tones are discrete impulses. Real-domain spectra (pre-ADC) get expanded into their
     // +-fc conjugate-symmetric half-power pair per Euler's formula before binning; post-ADC
     // complex-baseband spectra are already correctly one-sided and render as-is.
     std::vector<Spectrum::Tone> expanded_tones;
@@ -52,12 +54,29 @@ std::vector<double> SpectrumAnalyzerEngine::integratePowerPerBin(const Spectrum 
         int bin_idx =
             static_cast<int>(std::round((t.freq_Hz - spec.frequencies.front()) / bin_width));
         if (bin_idx >= 0 && static_cast<size_t>(bin_idx) < n) {
-            double tone_W = std::pow(10.0, (t.power_dBm - 30.0) / 10.0);
-            power_W[bin_idx] += tone_W;
+            tone_W[bin_idx] += std::pow(10.0, (t.power_dBm - 30.0) / 10.0);
         }
     }
+}
 
-    return power_W;
+std::vector<double>
+SpectrumAnalyzerEngine::toJitteredPower_dBm(const std::vector<double> &noise_W,
+                                            const std::vector<double> &tone_W) const {
+    std::vector<double> power_dBm(noise_W.size());
+    // Constructing the distribution is only defined for a positive sigma, so
+    // guard it: a disabled or invalid setting stays a pure no-op.
+    if (m_noise_jitter_enabled && m_noise_jitter_sigma_dB > 0.0) {
+        std::normal_distribution<double> jitter(0.0, m_noise_jitter_sigma_dB);
+        for (size_t i = 0; i < power_dBm.size(); ++i) {
+            double noise_W_i = noise_W[i] * std::pow(10.0, jitter(m_rng) / 10.0);
+            power_dBm[i] = W_to_dBm(noise_W_i + tone_W[i]);
+        }
+    } else {
+        for (size_t i = 0; i < power_dBm.size(); ++i) {
+            power_dBm[i] = W_to_dBm(noise_W[i] + tone_W[i]);
+        }
+    }
+    return power_dBm;
 }
 
 std::vector<double> SpectrumAnalyzerEngine::renderSpectrum(const Spectrum &spec) const {
@@ -71,33 +90,27 @@ std::vector<double> SpectrumAnalyzerEngine::renderSpectrum(const Spectrum &spec)
         bin_width = spec.frequencies[1] - spec.frequencies[0];
     }
 
-    // Cache the expensive integrate + RBW step. Jitter + VBW still run every
-    // frame so the display keeps its instrument-like live feel.
-    std::vector<double> rbw_power_W;
+    // Cache the expensive split + RBW step. Jitter + VBW still run every frame
+    // so the display keeps its instrument-like live feel.
+    std::vector<double> rbw_noise_W, rbw_tone_W;
     if (&spec == m_cache_spectrum && spec.generation == m_cache_spec_gen && m_rbw == m_cache_rbw &&
         bin_width == m_cache_bin_width) {
-        rbw_power_W = m_cache_rbw_power_W;
+        rbw_noise_W = m_cache_rbw_noise_W;
+        rbw_tone_W = m_cache_rbw_tone_W;
     } else {
-        std::vector<double> power_W = this->integratePowerPerBin(spec);
-        rbw_power_W = this->applyRBW(power_W, bin_width);
+        std::vector<double> noise_W, tone_W;
+        this->binPowerComponents(spec, noise_W, tone_W);
+        rbw_noise_W = this->applyRBW(noise_W, bin_width);
+        rbw_tone_W = this->applyRBW(tone_W, bin_width);
         m_cache_spectrum = &spec;
         m_cache_spec_gen = spec.generation;
         m_cache_rbw = m_rbw;
         m_cache_bin_width = bin_width;
-        m_cache_rbw_power_W = rbw_power_W;
+        m_cache_rbw_noise_W = rbw_noise_W;
+        m_cache_rbw_tone_W = rbw_tone_W;
     }
 
-    std::vector<double> power_dBm(rbw_power_W.size());
-    for (size_t i = 0; i < rbw_power_W.size(); ++i) {
-        power_dBm[i] = W_to_dBm(rbw_power_W[i]);
-    }
-
-    if (m_noise_jitter_enabled && m_noise_jitter_sigma_dB > 0.0) {
-        std::normal_distribution<double> jitter(0.0, m_noise_jitter_sigma_dB);
-        for (auto &p : power_dBm) {
-            p += jitter(m_rng);
-        }
-    }
+    std::vector<double> power_dBm = this->toJitteredPower_dBm(rbw_noise_W, rbw_tone_W);
 
     std::vector<double> vbw_out = this->applyVBW(power_dBm, bin_width);
     return this->applyTraceMode(spec, vbw_out);
@@ -120,16 +133,20 @@ SpectrumAnalyzerEngine::renderCombinedSpectrum(const std::vector<const Spectrum 
         return {};
     }
 
-    // Sum per-bin power (W). Use integratePowerPerBin for each Spectrum and add.
-    std::vector<double> sum_power_W(n, 0.0);
+    // Sum per-bin noise and tone power (W) separately so jitter can be applied
+    // to the noise floor without disturbing tone peaks.
+    std::vector<double> sum_noise_W(n, 0.0);
+    std::vector<double> sum_tone_W(n, 0.0);
     for (const Spectrum *s : specs) {
         if (!s) {
             continue;
         }
-        std::vector<double> p = this->integratePowerPerBin(*s);
-        size_t m = std::min(n, p.size());
+        std::vector<double> noise_W, tone_W;
+        this->binPowerComponents(*s, noise_W, tone_W);
+        size_t m = std::min(n, noise_W.size());
         for (size_t i = 0; i < m; ++i) {
-            sum_power_W[i] += p[i];
+            sum_noise_W[i] += noise_W[i];
+            sum_tone_W[i] += tone_W[i];
         }
     }
 
@@ -142,22 +159,11 @@ SpectrumAnalyzerEngine::renderCombinedSpectrum(const std::vector<const Spectrum 
         }
     }
 
-    std::vector<double> rbw_power_W = this->applyRBW(sum_power_W, bin_width);
+    std::vector<double> rbw_noise_W = this->applyRBW(sum_noise_W, bin_width);
+    std::vector<double> rbw_tone_W = this->applyRBW(sum_tone_W, bin_width);
 
-    std::vector<double> power_dBm(rbw_power_W.size());
-    for (size_t i = 0; i < rbw_power_W.size(); ++i) {
-        power_dBm[i] = W_to_dBm(rbw_power_W[i]);
-    }
-
-    // Add random noise jitter in dBm domain for visual "live" spectrum effect.
-    // Symmetric in dBm — no asymmetric clamping artifacts like power-domain jitter.
-    // VBW smooths this naturally; tone peaks are unaffected.
-    if (m_noise_jitter_enabled && m_noise_jitter_sigma_dB > 0.0) {
-        std::normal_distribution<double> jitter(0.0, m_noise_jitter_sigma_dB);
-        for (auto &p : power_dBm) {
-            p += jitter(m_rng);
-        }
-    }
+    // Jitter the noise floor only, then add the deterministic tone power back.
+    std::vector<double> power_dBm = this->toJitteredPower_dBm(rbw_noise_W, rbw_tone_W);
 
     std::vector<double> vbw_out = this->applyVBW(power_dBm, bin_width);
     return vbw_out;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -249,3 +249,11 @@ add_standalone_test(test_issue87_flow
          simulator::adc_engine simulator::pfb_channelizer_engine
          simulator::node_graph_engine
 )
+
+# Standalone coverage for the spectrum-display noise jitter: the cosmetic
+# noise-floor fluctuation must not move deterministic tone peaks. Kept outside
+# tests.exe for the MinGW-w64 registration-ceiling reason above.
+add_standalone_test(test_spectrum_jitter
+    SOURCES test_spectrum_jitter.cpp
+    LIBS simulator::spectrum_analyzer_engine
+)

--- a/tests/test_spectrum_jitter.cpp
+++ b/tests/test_spectrum_jitter.cpp
@@ -1,0 +1,154 @@
+#include "spectrum.h"
+#include "spectrum_analyzer_engine.h"
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+// Display noise jitter is a cosmetic "live instrument" effect on the noise
+// floor. Deterministic signal tones must not wander with it: the tone peak is
+// the same every frame, only the noise between tones fluctuates.
+
+namespace {
+
+constexpr size_t kBinCount = 101;
+constexpr int kToneBin = 50;
+constexpr double kBinWidth_Hz = 1e6;
+constexpr double kTonePower_dBm = -20.0;
+// 1e-20 W/Hz over a 1 MHz bin => 1e-14 W => -110 dBm noise floor, ~90 dB below
+// the tone, so any jitter leaking into the tone bin is easy to detect.
+constexpr double kNoiseDensity_W_per_Hz = 1e-20;
+
+Spectrum makeTonePlusNoise() {
+    Spectrum spec;
+    spec.frequencies.resize(kBinCount);
+    for (size_t i = 0; i < kBinCount; ++i)
+        spec.frequencies[i] = static_cast<double>(i) * kBinWidth_Hz;
+    spec.noise_total_W.assign(kBinCount, kNoiseDensity_W_per_Hz);
+    spec.tones = {{static_cast<double>(kToneBin) * kBinWidth_Hz, kTonePower_dBm, 0.0}};
+    // Complex-baseband: a single tone bin, no +-fc conjugate mirror to blur the
+    // peak location.
+    spec.is_complex_baseband = true;
+    spec.generation = 1;
+    return spec;
+}
+
+void configureJittered(SpectrumAnalyzerEngine &sa) {
+    sa.setNoiseJitterEnabled(true);
+    sa.setNoiseJitterSigmaDb(1.5);
+    sa.setResBw(kBinWidth_Hz);
+    sa.setVideoBw(kBinWidth_Hz); // window == 1 bin => VBW passthrough
+    sa.setTraceMode(TraceMode::ClearWrite);
+}
+
+double sampleStdDev(const std::vector<double> &v) {
+    double mean = std::accumulate(v.begin(), v.end(), 0.0) / static_cast<double>(v.size());
+    double acc = 0.0;
+    for (double x : v)
+        acc += (x - mean) * (x - mean);
+    return std::sqrt(acc / static_cast<double>(v.size()));
+}
+
+} // namespace
+
+TEST_CASE("SpectrumAnalyzer: jitter moves the noise floor but not a tone peak",
+          "[spectrum][jitter]") {
+    Spectrum spec = makeTonePlusNoise();
+
+    SpectrumAnalyzerEngine sa;
+    configureJittered(sa);
+
+    std::vector<double> tone_bin_samples;
+    std::vector<double> noise_bin_samples;
+    for (int frame = 0; frame < 200; ++frame) {
+        std::vector<double> trace = sa.renderSpectrum(spec);
+        REQUIRE(trace.size() == kBinCount);
+        tone_bin_samples.push_back(trace[kToneBin]);
+        noise_bin_samples.push_back(trace[20]); // far from the tone
+    }
+
+    // The noise floor must keep its live fluctuation.
+    REQUIRE(sampleStdDev(noise_bin_samples) > 0.5);
+    // The deterministic tone must stay put.
+    REQUIRE(sampleStdDev(tone_bin_samples) < 0.05);
+}
+
+TEST_CASE("SpectrumAnalyzer: combined trace jitter does not move a tone peak",
+          "[spectrum][jitter]") {
+    Spectrum spec = makeTonePlusNoise();
+
+    SpectrumAnalyzerEngine sa;
+    configureJittered(sa);
+
+    std::vector<const Spectrum *> specs = {&spec};
+    std::vector<double> tone_bin_samples;
+    std::vector<double> noise_bin_samples;
+    for (int frame = 0; frame < 200; ++frame) {
+        std::vector<double> trace = sa.renderCombinedSpectrum(specs);
+        REQUIRE(trace.size() == kBinCount);
+        tone_bin_samples.push_back(trace[kToneBin]);
+        noise_bin_samples.push_back(trace[20]);
+    }
+
+    REQUIRE(sampleStdDev(noise_bin_samples) > 0.5);
+    REQUIRE(sampleStdDev(tone_bin_samples) < 0.05);
+}
+
+TEST_CASE("SpectrumAnalyzer: jitter leaves a tone-only spectrum bit-identical",
+          "[spectrum][jitter]") {
+    // No noise floor to randomize: jitter must be a no-op, so two frames match
+    // exactly on both render paths instead of nudging the tone.
+    Spectrum spec = makeTonePlusNoise();
+    spec.noise_total_W.assign(kBinCount, 0.0);
+
+    SpectrumAnalyzerEngine sa;
+    configureJittered(sa);
+
+    std::vector<double> first = sa.renderSpectrum(spec);
+    std::vector<double> second = sa.renderSpectrum(spec);
+    std::vector<const Spectrum *> specs = {&spec};
+    std::vector<double> combined_first = sa.renderCombinedSpectrum(specs);
+    std::vector<double> combined_second = sa.renderCombinedSpectrum(specs);
+
+    REQUIRE(first.size() == second.size());
+    REQUIRE(combined_first.size() == combined_second.size());
+    for (size_t i = 0; i < first.size(); ++i) {
+        REQUIRE(first[i] == second[i]);
+        REQUIRE(combined_first[i] == combined_second[i]);
+    }
+}
+
+TEST_CASE("SpectrumAnalyzer: tone peak is unchanged when jitter is disabled",
+          "[spectrum][jitter]") {
+    Spectrum spec = makeTonePlusNoise();
+
+    SpectrumAnalyzerEngine sa;
+    configureJittered(sa);
+    sa.setNoiseJitterEnabled(false);
+
+    for (int frame = 0; frame < 10; ++frame) {
+        std::vector<double> trace = sa.renderSpectrum(spec);
+        REQUIRE(trace[kToneBin] > kTonePower_dBm - 0.5);
+        REQUIRE(trace[kToneBin] < kTonePower_dBm + 0.5);
+    }
+}
+
+TEST_CASE("SpectrumAnalyzer: non-positive jitter sigma is a safe no-op", "[spectrum][jitter]") {
+    // std::normal_distribution requires a positive sigma; an invalid setting
+    // must not be constructed and must leave rendering deterministic.
+    Spectrum spec = makeTonePlusNoise();
+
+    SpectrumAnalyzerEngine sa;
+    configureJittered(sa);
+    sa.setNoiseJitterSigmaDb(-1.0);
+
+    std::vector<double> first = sa.renderSpectrum(spec);
+    std::vector<double> second = sa.renderSpectrum(spec);
+    std::vector<const Spectrum *> specs = {&spec};
+    std::vector<double> combined = sa.renderCombinedSpectrum(specs);
+
+    REQUIRE(first.size() == second.size());
+    REQUIRE(combined.size() == first.size());
+    for (size_t i = 0; i < first.size(); ++i)
+        REQUIRE(first[i] == second[i]);
+}


### PR DESCRIPTION
## Summary

The spectrum display's cosmetic "live instrument" noise jitter was added to every display bin, so deterministic tone peaks wandered by the full jitter sigma (1.5 dB) instead of only the noise floor fluctuating.

## Related issue

N/A (no issue number provided)

## Type of change

- [x] Bug fix

## Test plan

- [x] `cmake -B build -G Ninja && cmake --build build`
- [x] `ctest --test-dir build --output-on-failure`
- [x] Manual verification steps (if applicable): the new `test_spectrum_jitter` executable reproduces the defect on the pre-fix code and passes after it.

## Details

**Root cause:** `SpectrumAnalyzerEngine::renderSpectrum` and `renderCombinedSpectrum` added `jitter(m_rng)` to every entry of `power_dBm` after the RBW filter. That sum already contains the tone energy, so tone peaks jittered by the full sigma; the code comment claiming "tone peaks are unaffected" was wrong.

**Fix:** `binPowerComponents()` splits per-bin power into a noise component and a tone-impulse component. RBW is applied to each independently (the convolution is linear, so this is identical to filtering the sum), then `toJitteredPower_dBm()` multiplies only the noise power by `10^(g/10)` and adds the deterministic tone power back. Applied to both render paths.

`std::normal_distribution` is constructed only when jitter is enabled with sigma > 0, preserving the old no-op behavior for disabled or invalid sigma (it has a positive-sigma precondition).

**Tests** — new standalone `test_spectrum_jitter` (kept out of `tests.exe` for the MinGW-w64 registration-ceiling reason):

- jitter moves the noise floor but not a tone peak (`renderSpectrum`)
- combined trace jitter does not move a tone peak
- a tone-only spectrum is bit-identical across frames on both render paths
- a non-positive sigma is a safe no-op

**Verification:** `tests.exe "~[bench]"` 221 cases / 66406 assertions; `tests.exe "[spectrum]"` 20 cases; `test_signal_domain`; `clang-format-18 --dry-run --Werror` clean on changed files.

Durable rule recorded in root `AGENTS.md` User Preferences.

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran `clang-format -i` on changed files
- [x] I added or updated tests where appropriate
- [x] Existing tests still pass
