### PR TITLE
fix: autoscale the network analyzer gain/NF plot

### DIFF
--- a/network_analyzer/src/network_analyzer_widget.cpp
+++ b/network_analyzer/src/network_analyzer_widget.cpp
@@ -3,9 +3,71 @@
 #include "implot.h"
 #include "node_graph_engine.h"
 #include "utils.h"
+#include <algorithm>
 #include <cmath>
 #include <string>
 #include <vector>
+
+namespace {
+
+// Axis limits framed on the plotted sweep and its measured values.
+struct PlotLimits {
+    bool valid = false;
+    double x_min = 0.0;
+    double x_max = 1.0;
+    double y_min = 0.0;
+    double y_max = 1.0;
+};
+
+// Minimum dB span so a flat trace (constant gain, or a single-point sweep)
+// still gets a readable axis instead of a near-zero window.
+constexpr double kMinDbSpan = 10.0;
+// Headroom kept above and below the measured values, as a fraction of the span.
+constexpr double kDbMargin = 0.1;
+
+// ImPlot auto-fits a plot only on the frame it is first drawn and never
+// again, so a panel opened before any probe point is selected -- or a sweep
+// changed afterwards -- keeps the range that was current then and squeezes the
+// traces into a corner. Frame the axes on the current data every frame
+// instead, as SpectrumAnalyzerWidget and IQPlotWidget do.
+PlotLimits plotLimitsFor(const std::vector<double> &freqs, const std::vector<double> &gain,
+                         const std::vector<double> &nf) {
+    PlotLimits limits;
+    if (freqs.empty() || freqs.size() != gain.size() || freqs.size() != nf.size())
+        return limits; // nothing is plotted: leave ImPlot's own range alone
+
+    const auto freq_ends = std::minmax_element(freqs.begin(), freqs.end());
+    limits.x_min = *freq_ends.first;
+    limits.x_max = *freq_ends.second;
+
+    double lo = 0.0;
+    double hi = 0.0;
+    bool have_sample = false;
+    for (const auto *series : {&gain, &nf}) {
+        for (double value : *series) {
+            if (!std::isfinite(value))
+                continue; // no path, or no matching tone, at that point
+            if (!have_sample) {
+                lo = hi = value;
+                have_sample = true;
+            } else {
+                lo = std::min(lo, value);
+                hi = std::max(hi, value);
+            }
+        }
+    }
+    if (!have_sample)
+        return limits; // nothing measured to frame
+
+    const double center = 0.5 * (lo + hi);
+    const double half_span = std::max(0.5 * (hi - lo), 0.5 * kMinDbSpan) * (1.0 + kDbMargin);
+    limits.y_min = center - half_span;
+    limits.y_max = center + half_span;
+    limits.valid = true;
+    return limits;
+}
+
+} // namespace
 
 NetworkAnalyzerWidget::NetworkAnalyzerWidget(NetworkAnalyzerEngine &engine, NodeGraphEngine &graph)
     : m_engine(engine), m_graph(graph) {}
@@ -87,6 +149,12 @@ void NetworkAnalyzerWidget::draw(const char *title, bool *p_open) {
     const auto &freqs = m_engine.sweepFrequencies();
     const auto &gain = m_engine.gainDb();
     const auto &nf = m_engine.noiseFigureDb();
+
+    // Frame the axes on the current sweep and measurement (see plotLimitsFor).
+    const PlotLimits limits = plotLimitsFor(freqs, gain, nf);
+    if (limits.valid)
+        ImPlot::SetNextAxesLimits(limits.x_min, limits.x_max, limits.y_min, limits.y_max,
+                                  ImPlotCond_Always);
 
     if (ImPlot::BeginPlot("Gain / Noise Figure vs Frequency", ImVec2(-1, -80))) {
         ImPlot::SetupAxes("Frequency (Hz)", "dB");

--- a/tests/test_network_analyzer.cpp
+++ b/tests/test_network_analyzer.cpp
@@ -520,6 +520,9 @@ TEST_CASE("NetworkAnalyzer: engine serialize/deserialize round-trip", "[network_
 // ---------------------------------------------------------------------------
 #include "imgui.h"
 #include "implot.h"
+// The axis ranges ImPlot settles on are only observable through its internals
+// (ImPlot::GetPlot); the pinned implot commit makes that stable.
+#include "implot_internal.h"
 
 namespace {
 struct ImGuiFixture {
@@ -575,4 +578,97 @@ TEST_CASE_METHOD(ImGuiFixture, "NetworkAnalyzer: widget draws with and without p
     widget.draw("Network Analyzer Test", &open);
     REQUIRE(open);
     ImGui::EndFrame();
+}
+
+namespace {
+// The plot object lives in the window that owns the plot id, so re-enter that
+// window for the lookup.
+ImPlotRange plotAxisRange(const char *window, const char *plot, ImAxis axis) {
+    ImGui::Begin(window);
+    ImPlotPlot *p = ImPlot::GetPlot(plot);
+    REQUIRE(p != nullptr);
+    const ImPlotRange range = p->Axes[axis].Range;
+    ImGui::End();
+    return range;
+}
+} // namespace
+
+// ImPlot only auto-fits a plot on the frame it is first drawn and never
+// again, so the gain/NF traces used to stay pinned to whatever range happened
+// to be current then -- including ImPlot's 0..1 default when the panel was
+// opened before any probe point was selected, which squeezed the measured
+// data into a corner of the plot.
+TEST_CASE_METHOD(ImGuiFixture, "NetworkAnalyzer: gain/NF plot scales to the measured sweep",
+                 "[network_analyzer][widget]") {
+    constexpr const char *kWindow = "Network Analyzer Scaling Test";
+    constexpr const char *kPlot = "Gain / Noise Figure vs Frequency";
+
+    NodeGraphEngine graph;
+    SignalGeneratorEngine gen(1, graph);
+    AttenuatorEngine atten(2, graph);
+    atten.setAttenuation(10.0);
+    graph.addLink(gen.outputPinId(), atten.inputPinId());
+    TestNaHost host({&gen, &atten});
+    NetworkAnalyzerEngine na(graph, host);
+    na.setStartFrequency(1e9);
+    na.setStopFrequency(2e9);
+    na.setPoints(11);
+
+    NetworkAnalyzerWidget widget(na, graph);
+    bool open = true;
+
+    // Frame 1: the panel is opened before any probe point is selected, so the
+    // plot is created with no data to fit. The size is pinned because a
+    // freshly created auto-sized window leaves the plot no rect to draw into.
+    ImGui::NewFrame();
+    ImGui::SetNextWindowSize(ImVec2(900, 700), ImGuiCond_Always);
+    widget.draw(kWindow, &open);
+    ImGui::EndFrame();
+    REQUIRE(open);
+
+    // Frame 2: probing a 1-2 GHz sweep with a 10 dB pad must frame that sweep
+    // on X and the -10 dB gain/NF traces on Y.
+    na.setPointA(gen.outputPinId());
+    na.setPointB(atten.outputPinId());
+    na.update();
+    ImGui::NewFrame();
+    widget.draw(kWindow, &open);
+    const ImPlotRange x = plotAxisRange(kWindow, kPlot, ImAxis_X1);
+    const ImPlotRange y = plotAxisRange(kWindow, kPlot, ImAxis_Y1);
+    ImGui::EndFrame();
+
+    REQUIRE_THAT(x.Min, WithinAbs(1e9, 1.0));
+    REQUIRE_THAT(x.Max, WithinAbs(2e9, 1.0));
+    REQUIRE(y.Min <= -10.0);
+    REQUIRE(y.Max >= -10.0);
+    REQUIRE(y.Max - y.Min < 100.0); // framed on the data, not a stale wide range
+
+    // Frame 3: changing the sweep re-frames the plot -- the stale-range half
+    // of the same bug.
+    na.setStartFrequency(2.4e9);
+    na.setStopFrequency(2.5e9);
+    na.update();
+    ImGui::NewFrame();
+    widget.draw(kWindow, &open);
+    const ImPlotRange moved = plotAxisRange(kWindow, kPlot, ImAxis_X1);
+    ImGui::EndFrame();
+
+    REQUIRE_THAT(moved.Min, WithinAbs(2.4e9, 1.0));
+    REQUIRE_THAT(moved.Max, WithinAbs(2.5e9, 1.0));
+
+    // Frame 4: a flat trace (0 dB pad -- constant gain and NF) still gets a
+    // readable dB window rather than a zero-height axis.
+    atten.setAttenuation(0.0);
+    na.update();
+    REQUIRE_FALSE(na.gainDb().empty());
+    for (double g : na.gainDb())
+        REQUIRE_THAT(g, WithinAbs(na.gainDb().front(), 1e-9)); // constant across the sweep
+    ImGui::NewFrame();
+    widget.draw(kWindow, &open);
+    const ImPlotRange flat = plotAxisRange(kWindow, kPlot, ImAxis_Y1);
+    ImGui::EndFrame();
+
+    REQUIRE(flat.Min <= 0.0);
+    REQUIRE(flat.Max >= 0.0);
+    REQUIRE(flat.Max - flat.Min >= 10.0); // never a degenerate dB axis
 }


### PR DESCRIPTION
## Summary

The Network Analyzer's Gain / Noise Figure plot now frames its axes on the current sweep and measurement, so the traces fill the plot instead of sitting in a corner of it.

## Related issue

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI

## Test plan

- [x] `cmake -B build -G Ninja && cmake --build build` (MinGW-w64 g++ 15.2.0, Windows)
- [x] `ctest --test-dir build --output-on-failure` - 254/254 pass
- [x] New regression test (below), verified failing before the fix and passing after
- [ ] Manual verification: no interactive GUI run; the new test drives the real widget with real ImGui/ImPlot contexts and reads back the axis ranges ImPlot settles on.

## What was wrong

ImPlot auto-fits a plot only on the frame it is first drawn and never again, and the widget passed no explicit limits. A plot created while there was nothing to draw - the panel opened before Point A/B were selected - kept ImPlot's 0..1 default range, and a later sweep or measurement change kept the range that was current at that first draw. Either way the measured data ended up outside, or squeezed into a corner of, the plotted area.

## What changed

- `network_analyzer/src/network_analyzer_widget.cpp`: derive the axes from the data every frame (X = sweep extent; Y = the finite gain/NF samples with 10% headroom and a 10 dB minimum span, so a flat trace still gets a readable axis), then apply them with `ImPlot::SetNextAxesLimits(..., ImPlotCond_Always)`, as `SpectrumAnalyzerWidget` and `IQPlotWidget` already do. With nothing measured, ImPlot's own range is left alone.
- `tests/test_network_analyzer.cpp`: regression test covering a panel opened before the probe points are chosen, a sweep change, and a flat (0 dB pad) trace.

Note: as with the spectrum analyzer and the I/Q plot, the axis ranges are now programmatic every frame, so mouse pan/zoom on this plot is suppressed.

## Checklist

- [x] My code follows the existing code style (see `.clang-format`)
- [x] I ran `clang-format -i` on changed files (`clang-format 18.1.8 --dry-run --Werror` is clean on both)
- [x] I added or updated tests where appropriate
- [x] Existing tests still pass

## Docs

No AGENTS.md or openwiki update: this is internal plot behavior with no contract, scope, ownership, or workflow change (openwiki is generated).
