### PR TITLE
chore: prepare release v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.23.1] - 2026-09-12
+
+### Fixed
+
+- **Network Analyzer plot autoscaling** — automatically scale the gain and noise-figure plots to the visible data range while preserving useful bounds for stable display.
+
+### Testing
+
+- Add regression coverage for gain and noise-figure plot autoscaling.
+
 ## [0.23.0] - 2026-09-11
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.20)
 
-project (RfSimulator VERSION 0.23.0)
+project (RfSimulator VERSION 0.23.1)
 
 # FetchContent'd dependencies below call their own project() commands, which
 # resets PROJECT_VERSION (and _MAJOR/_MINOR/_PATCH) for the remainder of this


### PR DESCRIPTION
Prepare patch release v0.23.1 following the documented release pipeline.

Includes the Network Analyzer autoscaling fix from PR #110 and its regression coverage.

Validation run locally:
- cmake --build build
- ctest --test-dir build --output-on-failure (254/254 passed)
- Format check attempted; clang-format 18 was unavailable in the environment.