### PR TITLE
chore: prepare release v0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.23.2] - 2026-09-12
+
+### Fixed
+
+- **Spectrum Analyzer tone stability** — keep cosmetic noise-floor jitter from moving deterministic tone peaks in spectrum displays.
+
+### Testing
+
+- Add standalone regression coverage for noisy tone traces, combined-spectrum rendering, tone-only determinism, and disabled/invalid jitter settings.
+
 ## [0.23.1] - 2026-09-12
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.20)
 
-project (RfSimulator VERSION 0.23.1)
+project (RfSimulator VERSION 0.23.2)
 
 # FetchContent'd dependencies below call their own project() commands, which
 # resets PROJECT_VERSION (and _MAJOR/_MINOR/_PATCH) for the remainder of this


### PR DESCRIPTION
## Summary\n\nPrepare patch release v0.23.2 for the merged Spectrum Analyzer tone-stability fix from PR #109.\n\n## Release contents\n\n- Update CMake project version to 0.23.2.\n- Add the curated 0.23.2 changelog entry.\n\n## Validation\n\n- CMake configure/build completed successfully.\n- Windows CTest validation completed with 246 tests, excluding Benchmark and headless test_ui.\n- clang-format 18 local wrapper could not be used because the environment's installed pip package resolves to clang-format 22; release-tag CI will run the authoritative clang-format-18 check.